### PR TITLE
Handle bad websocket auth

### DIFF
--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -1,7 +1,6 @@
 import asyncio
 import binascii
 import dataclasses
-import hashlib
 import os
 import os.path
 import random
@@ -187,8 +186,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             LOG.warning(f"Rejecting websocket connection: {e}")
             self.close(code=1008, reason=str(e))
             return
-        key_id = hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
-        LOG.info(f"Authorizing client - {useragent}:key:{key_id}")
+        LOG.info(f"Authorizing client - {useragent}:{key}")
 
         def do_send(payload: str, is_bin: bool):
             self.loop.install()  # TODO is this needed?

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -1,5 +1,4 @@
 import asyncio
-import binascii
 import dataclasses
 import os
 import os.path
@@ -144,18 +143,10 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         Returns:
             Tuple[str, str]: The decoded username and key.
         """
-        if not auth:
-            raise ValueError("missing authorization")
-        try:
-            userpass_encoded = bytes(auth.strip(), encoding="utf-8")
-            userpass_decoded = pybase64.b64decode(userpass_encoded, validate=True).decode("utf-8")
-        except (binascii.Error, UnicodeDecodeError) as e:
-            raise ValueError("invalid authorization encoding") from e
-        if ":" not in userpass_decoded:
-            raise ValueError("invalid authorization payload")
-        name, key = userpass_decoded.split(":", 1)
+        decoded = pybase64.b64decode(auth or "", validate=True).decode("utf-8")
+        name, key = decoded.split(":", 1)
         if not name or not key:
-            raise ValueError("invalid authorization payload")
+            raise ValueError("empty credentials")
         return name, key
 
     def on_message(self, message: str) -> None:
@@ -182,9 +173,13 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         auth = self.get_query_argument("authorization", None)
         try:
             useragent, key = self.decode_auth(auth)
-        except ValueError as e:
-            LOG.warning(f"Rejecting websocket connection: {e}")
-            self.close(code=1008, reason=str(e))
+        except (ValueError, UnicodeDecodeError) as e:
+            LOG.warning(
+                f"rejecting websocket from {self.request.remote_ip}: "
+                f"bad authorization ({e.__class__.__name__}: {e}) "
+                f"raw={auth!r}"
+            )
+            self.close(code=1008, reason="invalid authorization")
             return
         LOG.info(f"Authorizing client - {useragent}:{key}")
 
@@ -249,7 +244,10 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     def on_close(self):
         client = getattr(self, "client", None)
         if client is None:
-            LOG.debug("disconnecting unauthenticated websocket client")
+            LOG.debug(
+                f"closing unauthenticated websocket from {self.request.remote_ip} "
+                f"(no client was ever attached)"
+            )
             return
         LOG.info(f"disconnecting client: {client.peer}")
         self.hm_protocol.handle_client_disconnected(client)

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -148,7 +148,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             raise ValueError("missing authorization")
         try:
             userpass_encoded = bytes(auth.strip(), encoding="utf-8")
-            userpass_decoded = pybase64.b64decode(userpass_encoded).decode("utf-8")
+            userpass_decoded = pybase64.b64decode(userpass_encoded, validate=True).decode("utf-8")
         except (binascii.Error, UnicodeDecodeError) as e:
             raise ValueError("invalid authorization encoding") from e
         if ":" not in userpass_decoded:
@@ -186,7 +186,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             LOG.warning(f"Rejecting websocket connection: {e}")
             self.close(code=1008, reason=str(e))
             return
-        LOG.info(f"Authorizing client - {useragent}:{key}")
+        LOG.info(f"Authorizing client - {useragent}")
 
         def do_send(payload: str, is_bin: bool):
             self.loop.install()  # TODO is this needed?

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import binascii
 import dataclasses
 import os
 import os.path
@@ -143,9 +144,18 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         Returns:
             Tuple[str, str]: The decoded username and key.
         """
-        userpass_encoded = bytes(auth, encoding="utf-8")
-        userpass_decoded = pybase64.b64decode(userpass_encoded).decode("utf-8")
-        name, key = userpass_decoded.split(":")
+        if not auth:
+            raise ValueError("missing authorization")
+        try:
+            userpass_encoded = bytes(auth.strip(), encoding="utf-8")
+            userpass_decoded = pybase64.b64decode(userpass_encoded).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError) as e:
+            raise ValueError("invalid authorization encoding") from e
+        if ":" not in userpass_decoded:
+            raise ValueError("invalid authorization payload")
+        name, key = userpass_decoded.split(":", 1)
+        if not name or not key:
+            raise ValueError("invalid authorization payload")
         return name, key
 
     def on_message(self, message: str) -> None:
@@ -169,8 +179,13 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         """
         Handle a new client connection and perform authorization.
         """
-        auth = self.request.uri.split("/?authorization=")[-1]
-        useragent, key = self.decode_auth(auth)
+        auth = self.get_query_argument("authorization", None)
+        try:
+            useragent, key = self.decode_auth(auth)
+        except ValueError as e:
+            LOG.warning(f"Rejecting websocket connection: {e}")
+            self.close(code=1008, reason=str(e))
+            return
         LOG.info(f"Authorizing client - {useragent}:{key}")
 
         def do_send(payload: str, is_bin: bool):
@@ -232,8 +247,12 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         # self.write_message(Message("connected").serialize())
 
     def on_close(self):
-        LOG.info(f"disconnecting client: {self.client.peer}")
-        self.hm_protocol.handle_client_disconnected(self.client)
+        client = getattr(self, "client", None)
+        if client is None:
+            LOG.debug("disconnecting unauthenticated websocket client")
+            return
+        LOG.info(f"disconnecting client: {client.peer}")
+        self.hm_protocol.handle_client_disconnected(client)
 
     def check_origin(self, origin) -> bool:
         return True

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import binascii
 import dataclasses
+import hashlib
 import os
 import os.path
 import random
@@ -186,7 +187,8 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             LOG.warning(f"Rejecting websocket connection: {e}")
             self.close(code=1008, reason=str(e))
             return
-        LOG.info(f"Authorizing client - {useragent}")
+        key_id = hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
+        LOG.info(f"Authorizing client - {useragent}:key:{key_id}")
 
         def do_send(payload: str, is_bin: bool):
             self.loop.install()  # TODO is this needed?

--- a/tests/test_decode_auth.py
+++ b/tests/test_decode_auth.py
@@ -1,0 +1,60 @@
+"""Unit tests for HiveMindTornadoWebSocket.decode_auth.
+
+Regression coverage for the crash fixed in #12: bad base64 / malformed
+payloads used to raise binascii.Error out of pybase64.b64decode and crash
+the Tornado handler. decode_auth must now raise a plain ValueError (or
+UnicodeDecodeError) for every malformed-input case, which the caller in
+open() catches at the boundary.
+"""
+import pybase64
+import pytest
+
+from hivemind_websocket_protocol import HiveMindTornadoWebSocket
+
+
+def _encode(s: str) -> str:
+    return pybase64.b64encode(s.encode("utf-8")).decode("ascii")
+
+
+class TestDecodeAuthValid:
+    def test_simple_name_and_key(self):
+        assert HiveMindTornadoWebSocket.decode_auth(_encode("alice:secret")) == ("alice", "secret")
+
+    def test_key_containing_colon(self):
+        # split(":", 1) — colons inside the key must be preserved
+        assert HiveMindTornadoWebSocket.decode_auth(_encode("alice:a:b:c")) == ("alice", "a:b:c")
+
+    def test_unicode_name_and_key(self):
+        assert HiveMindTornadoWebSocket.decode_auth(_encode("ünïcødé:kéy")) == ("ünïcødé", "kéy")
+
+
+class TestDecodeAuthRejected:
+    """Every malformed input must raise ValueError or UnicodeDecodeError —
+    never a bare binascii.Error escaping into Tornado (the original crash)."""
+
+    @pytest.mark.parametrize("bad", [
+        None,
+        "",
+        "not_base64!@#",        # invalid base64 alphabet
+        "YWxpY2U",              # valid b64 but decodes to "alice" — no colon
+        _encode(":secret"),     # empty name
+        _encode("alice:"),      # empty key
+        _encode(":"),           # both empty
+        "QQ",                   # decodes to "A" — no colon
+    ])
+    def test_rejects_malformed(self, bad):
+        with pytest.raises((ValueError, UnicodeDecodeError)):
+            HiveMindTornadoWebSocket.decode_auth(bad)
+
+    def test_rejects_padding_error_from_traceback(self):
+        # This is the exact failure mode from the PR #12 traceback:
+        # pybase64.b64decode raised binascii.Error "Incorrect padding".
+        # It must now surface as ValueError so open() can catch it.
+        with pytest.raises(ValueError):
+            HiveMindTornadoWebSocket.decode_auth("YWxpY2U6c2VjcmV0X")
+
+    def test_rejects_invalid_utf8(self):
+        # valid base64, but the decoded bytes aren't valid UTF-8
+        bad = pybase64.b64encode(b"\xff\xfe:\xff").decode("ascii")
+        with pytest.raises((ValueError, UnicodeDecodeError)):
+            HiveMindTornadoWebSocket.decode_auth(bad)


### PR DESCRIPTION
Bad websocket auth was blowing up the listener.

This rejects missing or malformed `authorization` cleanly and avoids disconnect handling before a client exists.

```
2026-05-15 13:42:36,002 - WARNING - 400 GET / (10.42.1.83) 0.64ms
2026-05-15 13:42:39,766 - ERROR - Uncaught exception GET / (10.42.11.213)
HTTPServerRequest(protocol='http', host='jokes.hub.thalovant.io', method='GET', uri='/', version='HTTP/1.1', remote_ip='10.42.11.213')
Traceback (most recent call last):
  File "/home/hivemind/.venv/lib/python3.13/site-packages/tornado/websocket.py", line 965, in _accept_connection
    open_result = handler.open(*handler.open_args, **handler.open_kwargs)
  File "/home/hivemind/.venv/lib/python3.13/site-packages/hivemind_websocket_protocol/__init__.py", line 173, in open
    useragent, key = self.decode_auth(auth)
                     ~~~~~~~~~~~~~~~~^^^^^^
  File "/home/hivemind/.venv/lib/python3.13/site-packages/hivemind_websocket_protocol/__init__.py", line 147, in decode_auth
    userpass_decoded = pybase64.b64decode(userpass_encoded).decode("utf-8")
                       ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
binascii.Error: Incorrect padding
2026-05-15 13:43:32,440 - WARNING - 400 GET / (10.42.11.213) 0.53ms
2026-05-15 13:43:34,226 - ERROR - Uncaught exception GET / (10.42.11.213)
HTTPServerRequest(protocol='http', host='jokes.hub.thalovant.io', method='GET', uri='/', version='HTTP/1.1', remote_ip='10.42.11.213')
Traceback (most recent call last):
  File "/home/hivemind/.venv/lib/python3.13/site-packages/tornado/websocket.py", line 965, in _accept_connection
    open_result = handler.open(*handler.open_args, **handler.open_kwargs)
  File "/home/hivemind/.venv/lib/python3.13/site-packages/hivemind_websocket_protocol/__init__.py", line 173, in open
    useragent, key = self.decode_auth(auth)
                     ~~~~~~~~~~~~~~~~^^^^^^
  File "/home/hivemind/.venv/lib/python3.13/site-packages/hivemind_websocket_protocol/__init__.py", line 147, in decode_auth
    userpass_decoded = pybase64.b64decode(userpass_encoded).decode("utf-8")
                       ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
binascii.Error: Incorrect padding
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter WebSocket authentication validation with clearer, specific error reporting
  * Authorization failures now terminate the connection with an appropriate close code and warning
  * Improved handling of early/unauthenticated disconnects: logged at debug level and no longer trigger disconnection procedures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/hivemind-websocket-protocol/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->