### PR TITLE
Trust client IP from known proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ When the listener runs behind a proxy, it can log the real client IP from a
 trusted header:
 
 ```shell
-HIVEMIND_TRUSTED_PROXY_CIDRS=10.42.0.0/16
-HIVEMIND_TRUSTED_CLIENT_IP_HEADERS=x-hivemind-client-ip
+HIVEMIND_TRUSTED_PROXY_CIDRS=10.42.0.0/16,104.16.0.0/13
+HIVEMIND_TRUSTED_CLIENT_IP_HEADERS=x-forwarded-for
 ```
 
 The header is only used when the direct connection comes from a trusted proxy
-CIDR. The proxy should strip any incoming copy of the header and set it itself.
+CIDR. For forwarded chains, the listener walks from right to left and uses the
+first address that is not in the trusted proxy ranges.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 Transport HiveMessages via websockets
 
 This is the reference implementation of HiveMind, but you can theoretically replace websockets with anything
+
+## Trusted client IPs
+
+When the listener runs behind a proxy, it can log the real client IP from a
+trusted header:
+
+```shell
+HIVEMIND_TRUSTED_PROXY_CIDRS=10.42.0.0/16
+HIVEMIND_TRUSTED_CLIENT_IP_HEADERS=x-hivemind-client-ip
+```
+
+The header is only used when the direct connection comes from a trusted proxy
+CIDR. The proxy should strip any incoming copy of the header and set it itself.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ This is the reference implementation of HiveMind, but you can theoretically repl
 
 ## Trusted client IPs
 
-When the listener runs behind a proxy, it can log the real client IP from a
-trusted header:
+When the listener runs behind a proxy, it can log the real client IP from
+trusted headers (comma-separated if multiple):
 
 ```shell
 HIVEMIND_TRUSTED_PROXY_CIDRS=10.42.0.0/16,104.16.0.0/13
-HIVEMIND_TRUSTED_CLIENT_IP_HEADERS=x-forwarded-for
+HIVEMIND_TRUSTED_CLIENT_IP_HEADERS=x-forwarded-for,x-real-ip
 ```
 
-The header is only used when the direct connection comes from a trusted proxy
-CIDR. For forwarded chains, the listener walks from right to left and uses the
-first address that is not in the trusted proxy ranges.
+When not configured, the listener uses the direct connection's remote IP address
+without inspecting any forwarding headers.
+
+These headers are only consulted when the direct connection comes from a trusted
+proxy CIDR. For forwarded chains, the listener walks from right to left and uses
+the first address that is not in the trusted proxy ranges.

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -153,17 +153,24 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
 
     def _header_ip_candidates(self) -> list[str]:
         candidates: list[str] = []
-        for header in ("cf-connecting-ip", "x-real-ip", "x-client-ip"):
+        for header in (
+                "cf-connecting-ip",
+                "true-client-ip",
+                "x-envoy-external-address",
+                "x-real-ip",
+                "x-client-ip"
+        ):
             ip_value = self._normalize_ip(self.request.headers.get(header))
             if ip_value:
                 candidates.append(ip_value)
 
-        forwarded_for = self.request.headers.get("x-forwarded-for")
-        if isinstance(forwarded_for, str):
-            for value in forwarded_for.split(","):
-                ip_value = self._normalize_ip(value)
-                if ip_value:
-                    candidates.append(ip_value)
+        for header in ("x-forwarded-for", "x-original-forwarded-for"):
+            forwarded_for = self.request.headers.get(header)
+            if isinstance(forwarded_for, str):
+                for value in forwarded_for.split(","):
+                    ip_value = self._normalize_ip(value)
+                    if ip_value:
+                        candidates.append(ip_value)
 
         forwarded = self.request.headers.get("forwarded")
         if isinstance(forwarded, str):
@@ -195,8 +202,9 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         for candidate in candidates:
             if self._is_global_ip(candidate):
                 return candidate
-        return remote_ip or (candidates[0] if candidates else None)
-
+        if candidates:
+            return candidates[0]
+        return remote_ip
 
     @staticmethod
     def decode_auth(auth: str) -> Tuple[str, str]:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -1,7 +1,6 @@
 import asyncio
 import binascii
 import dataclasses
-import hashlib
 import os
 import os.path
 import random
@@ -187,8 +186,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             LOG.warning(f"Rejecting websocket connection: {e}")
             self.close(code=1008, reason=str(e))
             return
-        key_id = hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
-        LOG.info(f"Authorizing client - {useragent}:key:{key_id}")
+        LOG.info(f"Authorizing client - {useragent}:{key}")
 
         def do_send(payload: str, is_bin: bool):
             self.loop.install()  # TODO is this needed?

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -151,15 +151,6 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         except ValueError:
             return None
 
-    @staticmethod
-    def _trust_proxy_ip_headers() -> bool:
-        return os.getenv("HIVEMIND_TRUST_PROXY_IP_HEADERS", "").strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
-
     def _header_ip_candidates(self) -> list[str]:
         candidates: list[str] = []
         for header in ("cf-connecting-ip", "x-real-ip", "x-client-ip"):
@@ -196,23 +187,16 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             return False
 
     def _connection_ip(self) -> Optional[str]:
-        envoy_external_ip = self._normalize_ip(
-            self.request.headers.get("x-envoy-external-address")
-        )
-        if self._is_global_ip(envoy_external_ip):
-            return envoy_external_ip
-
         remote_ip = self._normalize_ip(getattr(self.request, "remote_ip", None))
         if self._is_global_ip(remote_ip):
             return remote_ip
 
-        if self._trust_proxy_ip_headers():
-            candidates = self._header_ip_candidates()
-            for candidate in candidates:
-                if self._is_global_ip(candidate):
-                    return candidate
-            return remote_ip or (candidates[0] if candidates else None)
-        return remote_ip
+        candidates = self._header_ip_candidates()
+        for candidate in candidates:
+            if self._is_global_ip(candidate):
+                return candidate
+        return remote_ip or (candidates[0] if candidates else None)
+
 
     @staticmethod
     def decode_auth(auth: str) -> Tuple[str, str]:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import binascii
 import dataclasses
 import os
 import os.path
@@ -143,9 +144,18 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         Returns:
             Tuple[str, str]: The decoded username and key.
         """
-        userpass_encoded = bytes(auth, encoding="utf-8")
-        userpass_decoded = pybase64.b64decode(userpass_encoded).decode("utf-8")
-        name, key = userpass_decoded.split(":")
+        if not auth:
+            raise ValueError("missing authorization")
+        try:
+            userpass_encoded = bytes(auth.strip(), encoding="utf-8")
+            userpass_decoded = pybase64.b64decode(userpass_encoded, validate=True).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError) as e:
+            raise ValueError("invalid authorization encoding") from e
+        if ":" not in userpass_decoded:
+            raise ValueError("invalid authorization payload")
+        name, key = userpass_decoded.split(":", 1)
+        if not name or not key:
+            raise ValueError("invalid authorization payload")
         return name, key
 
     def on_message(self, message: str) -> None:
@@ -169,9 +179,14 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         """
         Handle a new client connection and perform authorization.
         """
-        auth = self.request.uri.split("/?authorization=")[-1]
-        useragent, key = self.decode_auth(auth)
-        LOG.info(f"Authorizing client - {useragent}:{key}")
+        auth = self.get_query_argument("authorization", None)
+        try:
+            useragent, key = self.decode_auth(auth)
+        except ValueError as e:
+            LOG.warning(f"Rejecting websocket connection: {e}")
+            self.close(code=1008, reason=str(e))
+            return
+        LOG.info(f"Authorizing client - {useragent}")
 
         def do_send(payload: str, is_bin: bool):
             self.loop.install()  # TODO is this needed?
@@ -232,8 +247,12 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         # self.write_message(Message("connected").serialize())
 
     def on_close(self):
-        LOG.info(f"disconnecting client: {self.client.peer}")
-        self.hm_protocol.handle_client_disconnected(self.client)
+        client = getattr(self, "client", None)
+        if client is None:
+            LOG.debug("disconnecting unauthenticated websocket client")
+            return
+        LOG.info(f"disconnecting client: {client.peer}")
+        self.hm_protocol.handle_client_disconnected(client)
 
     def check_origin(self, origin) -> bool:
         return True

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -153,24 +153,17 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
 
     def _header_ip_candidates(self) -> list[str]:
         candidates: list[str] = []
-        for header in (
-                "cf-connecting-ip",
-                "true-client-ip",
-                "x-envoy-external-address",
-                "x-real-ip",
-                "x-client-ip"
-        ):
+        for header in ("cf-connecting-ip", "x-real-ip", "x-client-ip"):
             ip_value = self._normalize_ip(self.request.headers.get(header))
             if ip_value:
                 candidates.append(ip_value)
 
-        for header in ("x-forwarded-for", "x-original-forwarded-for"):
-            forwarded_for = self.request.headers.get(header)
-            if isinstance(forwarded_for, str):
-                for value in forwarded_for.split(","):
-                    ip_value = self._normalize_ip(value)
-                    if ip_value:
-                        candidates.append(ip_value)
+        forwarded_for = self.request.headers.get("x-forwarded-for")
+        if isinstance(forwarded_for, str):
+            for value in forwarded_for.split(","):
+                ip_value = self._normalize_ip(value)
+                if ip_value:
+                    candidates.append(ip_value)
 
         forwarded = self.request.headers.get("forwarded")
         if isinstance(forwarded, str):
@@ -202,9 +195,8 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         for candidate in candidates:
             if self._is_global_ip(candidate):
                 return candidate
-        if candidates:
-            return candidates[0]
-        return remote_ip
+        return remote_ip or (candidates[0] if candidates else None)
+
 
     @staticmethod
     def decode_auth(auth: str) -> Tuple[str, str]:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import binascii
 import dataclasses
+import ipaddress
 import os
 import os.path
 import random
@@ -134,6 +135,70 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     hm_protocol = None
 
     @staticmethod
+    def _normalize_ip(value: str | None) -> Optional[str]:
+        if not isinstance(value, str):
+            return None
+        candidate = value.strip().strip('"')
+        if not candidate:
+            return None
+        if candidate.startswith("[") and "]" in candidate:
+            candidate = candidate[1:candidate.index("]")]
+        elif candidate.count(":") == 1 and "." in candidate:
+            candidate = candidate.rsplit(":", 1)[0]
+        candidate = candidate.split("%", 1)[0]
+        try:
+            return str(ipaddress.ip_address(candidate))
+        except ValueError:
+            return None
+
+    def _header_ip_candidates(self) -> list[str]:
+        candidates: list[str] = []
+        for header in ("cf-connecting-ip", "x-real-ip", "x-client-ip"):
+            ip_value = self._normalize_ip(self.request.headers.get(header))
+            if ip_value:
+                candidates.append(ip_value)
+
+        forwarded_for = self.request.headers.get("x-forwarded-for")
+        if isinstance(forwarded_for, str):
+            for value in forwarded_for.split(","):
+                ip_value = self._normalize_ip(value)
+                if ip_value:
+                    candidates.append(ip_value)
+
+        forwarded = self.request.headers.get("forwarded")
+        if isinstance(forwarded, str):
+            for entry in forwarded.split(","):
+                for token in entry.split(";"):
+                    key, separator, value = token.strip().partition("=")
+                    if separator and key.lower() == "for":
+                        ip_value = self._normalize_ip(value)
+                        if ip_value:
+                            candidates.append(ip_value)
+
+        return list(dict.fromkeys(candidates))
+
+    @staticmethod
+    def _is_global_ip(value: str | None) -> bool:
+        if not value:
+            return False
+        try:
+            return ipaddress.ip_address(value).is_global
+        except ValueError:
+            return False
+
+    def _connection_ip(self) -> Optional[str]:
+        remote_ip = self._normalize_ip(getattr(self.request, "remote_ip", None))
+        if self._is_global_ip(remote_ip):
+            return remote_ip
+
+        candidates = self._header_ip_candidates()
+        for candidate in candidates:
+            if self._is_global_ip(candidate):
+                return candidate
+        return remote_ip or (candidates[0] if candidates else None)
+
+
+    @staticmethod
     def decode_auth(auth: str) -> Tuple[str, str]:
         """
         Decode the base64 encoded authorization string.
@@ -166,27 +231,30 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             message (str): The incoming message.
         """
         message = self.client.decode(message)
+        source_ip = getattr(self.client, "source_ip", None)
+        source_label = f" from {source_ip}" if source_ip else ""
         if (
                 message.msg_type == HiveMessageType.BUS
                 and message.payload.msg_type == "recognizer_loop:b64_audio"
         ):
-            LOG.info(f"Received {self.client.peer} sent base64 audio for STT")
+            LOG.info(f"Received {self.client.peer}{source_label} sent base64 audio for STT")
         else:
-            LOG.info(f"Received {self.client.peer} message: {message}")
+            LOG.info(f"Received {self.client.peer}{source_label} message: {message}")
         self.hm_protocol.handle_message(message, self.client)
 
     def open(self) -> None:
         """
         Handle a new client connection and perform authorization.
         """
+        source_ip = self._connection_ip()
         auth = self.get_query_argument("authorization", None)
         try:
             useragent, key = self.decode_auth(auth)
         except ValueError as e:
-            LOG.warning(f"Rejecting websocket connection: {e}")
+            LOG.warning(f"Rejecting websocket connection from {source_ip or 'unknown'}: {e}")
             self.close(code=1008, reason=str(e))
             return
-        LOG.info(f"Authorizing client - {useragent}:{key}")
+        LOG.info(f"Authorizing client from {source_ip or 'unknown'} - {useragent}")
 
         def do_send(payload: str, is_bin: bool):
             self.loop.install()  # TODO is this needed?
@@ -204,6 +272,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             name=useragent,
             hm_protocol=self.hm_protocol
         )
+        self.client.source_ip = source_ip
         self.hm_protocol.db.sync()
         user: Client = self.hm_protocol.db.get_client_by_api_key(key)
 
@@ -251,7 +320,9 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         if client is None:
             LOG.debug("disconnecting unauthenticated websocket client")
             return
-        LOG.info(f"disconnecting client: {client.peer}")
+        source_ip = getattr(client, "source_ip", None)
+        source_label = f" from {source_ip}" if source_ip else ""
+        LOG.info(f"disconnecting client: {client.peer}{source_label}")
         self.hm_protocol.handle_client_disconnected(client)
 
     def check_origin(self, origin) -> bool:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -9,6 +9,7 @@ from os import makedirs
 from os.path import exists, join
 from socket import gethostname
 from typing import Dict, Any, Optional, Tuple
+from urllib.parse import unquote
 
 import pybase64
 from OpenSSL import crypto
@@ -193,8 +194,9 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         except ValueError:
             return None
 
-    def _header_ip_candidates(self) -> list[str]:
-        candidates: list[str] = []
+    def _header_ip_candidates(self) -> list[list[str]]:
+        candidate_groups: list[list[str]] = []
+        seen: set[str] = set()
         for header in self.trusted_client_ip_headers:
             header_value = self.request.headers.get(header)
             if not isinstance(header_value, str):
@@ -211,12 +213,17 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             else:
                 values = [header_value]
 
+            candidates: list[str] = []
             for value in values:
                 ip_value = self._normalize_ip(value)
-                if ip_value:
+                if ip_value and ip_value not in seen:
                     candidates.append(ip_value)
+                    seen.add(ip_value)
 
-        return list(dict.fromkeys(candidates))
+            if candidates:
+                candidate_groups.append(candidates)
+
+        return candidate_groups
 
     @staticmethod
     def _is_global_ip(value: str | None) -> bool:
@@ -230,8 +237,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     def _connection_ip(self) -> Optional[str]:
         remote_ip = self._normalize_ip(getattr(self.request, "remote_ip", None))
         if self._is_trusted_proxy(remote_ip):
-            candidates = self._header_ip_candidates()
-            if candidates:
+            for candidates in self._header_ip_candidates():
                 return self._client_ip_from_candidates(candidates)
         if self._is_global_ip(remote_ip):
             return remote_ip
@@ -279,6 +285,18 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             raise ValueError("invalid authorization payload")
         return name, key
 
+    @staticmethod
+    def _query_argument(query: str | bytes | None, name: str) -> Optional[str]:
+        if isinstance(query, bytes):
+            query = query.decode("utf-8", errors="ignore")
+        if not isinstance(query, str) or not query:
+            return None
+        for part in query.split("&"):
+            key, separator, value = part.partition("=")
+            if unquote(key) == name:
+                return unquote(value) if separator else ""
+        return None
+
     def on_message(self, message: str) -> None:
         """
         Handle incoming messages from the WebSocket.
@@ -303,7 +321,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         Handle a new client connection and perform authorization.
         """
         source_ip = self._connection_ip()
-        auth = self.get_query_argument("authorization", None)
+        auth = self._query_argument(getattr(self.request, "query", None), "authorization")
         try:
             useragent, key = self.decode_auth(auth)
         except ValueError as e:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -232,10 +232,16 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         if self._is_trusted_proxy(remote_ip):
             candidates = self._header_ip_candidates()
             if candidates:
-                return candidates[0]
+                return self._client_ip_from_candidates(candidates)
         if self._is_global_ip(remote_ip):
             return remote_ip
         return remote_ip
+
+    def _client_ip_from_candidates(self, candidates: list[str]) -> str:
+        for candidate in reversed(candidates):
+            if not self._is_trusted_proxy(candidate):
+                return candidate
+        return candidates[0]
 
     @classmethod
     def _is_trusted_proxy(cls, remote_ip: str | None) -> bool:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -151,6 +151,15 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         except ValueError:
             return None
 
+    @staticmethod
+    def _trust_proxy_ip_headers() -> bool:
+        return os.getenv("HIVEMIND_TRUST_PROXY_IP_HEADERS", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
     def _header_ip_candidates(self) -> list[str]:
         candidates: list[str] = []
         for header in ("cf-connecting-ip", "x-real-ip", "x-client-ip"):
@@ -187,16 +196,23 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             return False
 
     def _connection_ip(self) -> Optional[str]:
+        envoy_external_ip = self._normalize_ip(
+            self.request.headers.get("x-envoy-external-address")
+        )
+        if self._is_global_ip(envoy_external_ip):
+            return envoy_external_ip
+
         remote_ip = self._normalize_ip(getattr(self.request, "remote_ip", None))
         if self._is_global_ip(remote_ip):
             return remote_ip
 
-        candidates = self._header_ip_candidates()
-        for candidate in candidates:
-            if self._is_global_ip(candidate):
-                return candidate
-        return remote_ip or (candidates[0] if candidates else None)
-
+        if self._trust_proxy_ip_headers():
+            candidates = self._header_ip_candidates()
+            for candidate in candidates:
+                if self._is_global_ip(candidate):
+                    return candidate
+            return remote_ip or (candidates[0] if candidates else None)
+        return remote_ip
 
     @staticmethod
     def decode_auth(auth: str) -> Tuple[str, str]:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -71,15 +71,18 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
         asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
         HiveMindTornadoWebSocket.loop = ioloop.IOLoop.current()
         HiveMindTornadoWebSocket.hm_protocol = self.hm_protocol
-        proxy_cidrs = (
-            self.config.get("trusted_proxy_cidrs")
-            or os.getenv("HIVEMIND_TRUSTED_PROXY_CIDRS")
-        )
-        client_ip_headers = (
-            self.config.get("trusted_client_ip_headers")
-            or os.getenv("HIVEMIND_TRUSTED_CLIENT_IP_HEADERS")
-            or "x-hivemind-client-ip"
-        )
+        if "trusted_proxy_cidrs" in self.config:
+            proxy_cidrs = self.config["trusted_proxy_cidrs"]
+        else:
+            proxy_cidrs = os.getenv("HIVEMIND_TRUSTED_PROXY_CIDRS")
+
+        if "trusted_client_ip_headers" in self.config:
+            client_ip_headers = self.config["trusted_client_ip_headers"]
+        else:
+            client_ip_headers = (
+                os.getenv("HIVEMIND_TRUSTED_CLIENT_IP_HEADERS")
+                or "x-hivemind-client-ip"
+            )
         HiveMindTornadoWebSocket.trusted_proxy_networks = self._trusted_proxy_networks(
             proxy_cidrs
         )
@@ -226,13 +229,12 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
 
     def _connection_ip(self) -> Optional[str]:
         remote_ip = self._normalize_ip(getattr(self.request, "remote_ip", None))
-        if self._is_global_ip(remote_ip):
-            return remote_ip
-
         if self._is_trusted_proxy(remote_ip):
             candidates = self._header_ip_candidates()
             if candidates:
                 return candidates[0]
+        if self._is_global_ip(remote_ip):
+            return remote_ip
         return remote_ip
 
     @classmethod

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import binascii
 import dataclasses
+import hashlib
 import os
 import os.path
 import random
@@ -186,7 +187,8 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             LOG.warning(f"Rejecting websocket connection: {e}")
             self.close(code=1008, reason=str(e))
             return
-        LOG.info(f"Authorizing client - {useragent}")
+        key_id = hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
+        LOG.info(f"Authorizing client - {useragent}:key:{key_id}")
 
         def do_send(payload: str, is_bin: bool):
             self.loop.install()  # TODO is this needed?

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -44,11 +44,48 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
     hm_protocol: Optional[HiveMindListenerProtocol] = None
     callbacks: ClientCallbacks = dataclasses.field(default_factory=ClientCallbacks)
 
+    @staticmethod
+    def _config_list(value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        if isinstance(value, (list, tuple, set)):
+            items = [str(item).strip() for item in value]
+            return [item for item in items if item]
+        item = str(value).strip()
+        return [item] if item else []
+
+    @classmethod
+    def _trusted_proxy_networks(cls, value: Any) -> tuple[Any, ...]:
+        networks = []
+        for proxy_cidr in cls._config_list(value):
+            try:
+                networks.append(ipaddress.ip_network(proxy_cidr, strict=False))
+            except ValueError:
+                LOG.warning(f"Ignoring invalid trusted proxy CIDR: {proxy_cidr}")
+        return tuple(networks)
+
     def run(self):
         LOG.debug(f"websocket server config: {self.config}")
         asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
         HiveMindTornadoWebSocket.loop = ioloop.IOLoop.current()
         HiveMindTornadoWebSocket.hm_protocol = self.hm_protocol
+        proxy_cidrs = (
+            self.config.get("trusted_proxy_cidrs")
+            or os.getenv("HIVEMIND_TRUSTED_PROXY_CIDRS")
+        )
+        client_ip_headers = (
+            self.config.get("trusted_client_ip_headers")
+            or os.getenv("HIVEMIND_TRUSTED_CLIENT_IP_HEADERS")
+            or "x-hivemind-client-ip"
+        )
+        HiveMindTornadoWebSocket.trusted_proxy_networks = self._trusted_proxy_networks(
+            proxy_cidrs
+        )
+        HiveMindTornadoWebSocket.trusted_client_ip_headers = tuple(
+            header.lower() for header in self._config_list(client_ip_headers)
+        )
 
         ssl = self.config.get("ssl", False)
         cert_dir: str = self.config.get("cert_dir") or f"{xdg_data_home()}/hivemind"
@@ -63,7 +100,7 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
             cert_file = f"{cert_dir}/{cert_name}.crt"
             key_file = f"{cert_dir}/{cert_name}.key"
             if not os.path.isfile(key_file):
-                LOG.info(f"generating self-signed SSL certificate")
+                LOG.info("generating self-signed SSL certificate")
                 cert_file, key_file = self.create_self_signed_cert(cert_dir, cert_name)
             LOG.debug("using ssl key at " + key_file)
             LOG.debug("using ssl certificate at " + cert_file)
@@ -133,6 +170,8 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         hm_protocol (Optional[HiveMindListenerProtocol]): The protocol instance for handling HiveMind messages.
     """
     hm_protocol = None
+    trusted_client_ip_headers: tuple[str, ...] = ("x-hivemind-client-ip",)
+    trusted_proxy_networks: tuple[Any, ...] = ()
 
     @staticmethod
     def _normalize_ip(value: str | None) -> Optional[str]:
@@ -153,27 +192,26 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
 
     def _header_ip_candidates(self) -> list[str]:
         candidates: list[str] = []
-        for header in ("cf-connecting-ip", "x-real-ip", "x-client-ip"):
-            ip_value = self._normalize_ip(self.request.headers.get(header))
-            if ip_value:
-                candidates.append(ip_value)
+        for header in self.trusted_client_ip_headers:
+            header_value = self.request.headers.get(header)
+            if not isinstance(header_value, str):
+                continue
+            if header == "x-forwarded-for":
+                values = header_value.split(",")
+            elif header == "forwarded":
+                values = []
+                for entry in header_value.split(","):
+                    for token in entry.split(";"):
+                        key, separator, value = token.strip().partition("=")
+                        if separator and key.lower() == "for":
+                            values.append(value)
+            else:
+                values = [header_value]
 
-        forwarded_for = self.request.headers.get("x-forwarded-for")
-        if isinstance(forwarded_for, str):
-            for value in forwarded_for.split(","):
+            for value in values:
                 ip_value = self._normalize_ip(value)
                 if ip_value:
                     candidates.append(ip_value)
-
-        forwarded = self.request.headers.get("forwarded")
-        if isinstance(forwarded, str):
-            for entry in forwarded.split(","):
-                for token in entry.split(";"):
-                    key, separator, value = token.strip().partition("=")
-                    if separator and key.lower() == "for":
-                        ip_value = self._normalize_ip(value)
-                        if ip_value:
-                            candidates.append(ip_value)
 
         return list(dict.fromkeys(candidates))
 
@@ -191,11 +229,21 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         if self._is_global_ip(remote_ip):
             return remote_ip
 
-        candidates = self._header_ip_candidates()
-        for candidate in candidates:
-            if self._is_global_ip(candidate):
-                return candidate
-        return remote_ip or (candidates[0] if candidates else None)
+        if self._is_trusted_proxy(remote_ip):
+            candidates = self._header_ip_candidates()
+            if candidates:
+                return candidates[0]
+        return remote_ip
+
+    @classmethod
+    def _is_trusted_proxy(cls, remote_ip: str | None) -> bool:
+        if not remote_ip or not cls.trusted_proxy_networks:
+            return False
+        try:
+            ip_address = ipaddress.ip_address(remote_ip)
+        except ValueError:
+            return False
+        return any(ip_address in network for network in cls.trusted_proxy_networks)
 
 
     @staticmethod


### PR DESCRIPTION
## Summary
Adds a trusted proxy path for the listener client IP.

When the listener runs behind a proxy, `request.remote_ip` can be the proxy or pod IP. This lets the edge set one trusted header and lets HiveMind use it only when the direct peer matches configured trusted CIDRs.

Default behavior stays the same when not configured.

Refs #13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded websockets protocol documentation with configurable trusted client IP and proxy guidance

* **New Features**
  * Added configurable trusted proxy handling and automatic client IP extraction for websocket connections
  * Enhanced websocket logging to display resolved source IP for all messages

* **Improvements**
  * Strengthened authorization validation with explicit error detection and handling
  * Improved websocket connection lifecycle for secure handling of unauthenticated connections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/hivemind-websocket-protocol/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->