### PR TITLE
feat: trusted client IP from known proxies (supersedes #14)

### DIFF
--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -29,6 +29,22 @@ from hivemind_core.protocol import (
 from hivemind_plugin_manager.protocols import ClientCallbacks
 from hivemind_plugin_manager.database import Client
 
+from hivemind_websocket_protocol._client_ip import (
+    parse_networks,
+    resolve_client_ip,
+)
+
+
+DEFAULT_TRUSTED_HEADERS = "x-forwarded-for,x-real-ip"
+
+
+def _split_csv(value: Any) -> Tuple[str, ...]:
+    if not value:
+        return ()
+    if isinstance(value, str):
+        return tuple(v.strip() for v in value.split(",") if v.strip())
+    return tuple(str(v).strip() for v in value if str(v).strip())
+
 
 @dataclasses.dataclass
 class HiveMindWebsocketProtocol(NetworkProtocol):
@@ -48,6 +64,17 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
         HiveMindTornadoWebSocket.loop = ioloop.IOLoop.current()
         HiveMindTornadoWebSocket.hm_protocol = self.hm_protocol
 
+        proxy_cidrs = self.config.get("trusted_proxy_cidrs") or os.getenv(
+            "HIVEMIND_TRUSTED_PROXY_CIDRS"
+        )
+        client_ip_headers = (
+            self.config.get("trusted_client_ip_headers")
+            or os.getenv("HIVEMIND_TRUSTED_CLIENT_IP_HEADERS")
+            or DEFAULT_TRUSTED_HEADERS
+        )
+        trusted_networks = parse_networks(_split_csv(proxy_cidrs))
+        trusted_headers = tuple(h.lower() for h in _split_csv(client_ip_headers))
+
         ssl = self.config.get("ssl", False)
         cert_dir: str = self.config.get("cert_dir") or f"{xdg_data_home()}/hivemind"
         cert_name: str = self.config.get("cert_name") or "hivemind"
@@ -56,7 +83,11 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
         port = int(self.config.get("port") or self.identity.default_port or 5678)
 
         routes: list = [("/", HiveMindTornadoWebSocket)]
-        application = web.Application(routes)
+        application = web.Application(
+            routes,
+            trusted_networks=trusted_networks,
+            trusted_headers=trusted_headers,
+        )
         if ssl:
             cert_file = f"{cert_dir}/{cert_name}.crt"
             key_file = f"{cert_dir}/{cert_name}.key"
@@ -132,6 +163,14 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     """
     hm_protocol = None
 
+    def _client_ip(self) -> Optional[str]:
+        return resolve_client_ip(
+            getattr(self.request, "remote_ip", None),
+            self.request.headers,
+            self.settings.get("trusted_networks", ()),
+            self.settings.get("trusted_headers", ()),
+        )
+
     @staticmethod
     def decode_auth(auth: str) -> Tuple[str, str]:
         """
@@ -150,38 +189,39 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         return name, key
 
     def on_message(self, message: str) -> None:
-        """
-        Handle incoming messages from the WebSocket.
-
-        Args:
-            message (str): The incoming message.
-        """
         message = self.client.decode(message)
+        peer = self._peer_label(self.client)
         if (
                 message.msg_type == HiveMessageType.BUS
                 and message.payload.msg_type == "recognizer_loop:b64_audio"
         ):
-            LOG.info(f"Received {self.client.peer} sent base64 audio for STT")
+            LOG.info(f"Received {peer} sent base64 audio for STT")
         else:
-            LOG.info(f"Received {self.client.peer} message: {message}")
+            LOG.info(f"Received {peer} message: {message}")
         self.hm_protocol.handle_message(message, self.client)
+
+    @staticmethod
+    def _peer_label(client) -> str:
+        ip = getattr(client, "source_ip", None)
+        return f"{client.peer} ({ip})" if ip else client.peer
 
     def open(self) -> None:
         """
         Handle a new client connection and perform authorization.
         """
+        source_ip = self._client_ip()
         auth = self.get_query_argument("authorization", None)
         try:
             useragent, key = self.decode_auth(auth)
         except (ValueError, UnicodeDecodeError) as e:
             LOG.warning(
-                f"rejecting websocket from {self.request.remote_ip}: "
+                f"rejecting websocket from {source_ip or self.request.remote_ip}: "
                 f"bad authorization ({e.__class__.__name__}: {e}) "
                 f"raw={auth!r}"
             )
             self.close(code=1008, reason="invalid authorization")
             return
-        LOG.info(f"Authorizing client - {useragent}:{key}")
+        LOG.info(f"Authorizing client from {source_ip or 'unknown'} - {useragent}:{key}")
 
         def do_send(payload: str, is_bin: bool):
             self.loop.install()  # TODO is this needed?
@@ -199,6 +239,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             name=useragent,
             hm_protocol=self.hm_protocol
         )
+        self.client.source_ip = source_ip
         self.hm_protocol.db.sync()
         user: Client = self.hm_protocol.db.get_client_by_api_key(key)
 
@@ -249,7 +290,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
                 f"(no client was ever attached)"
             )
             return
-        LOG.info(f"disconnecting client: {client.peer}")
+        LOG.info(f"disconnecting client: {self._peer_label(client)}")
         self.hm_protocol.handle_client_disconnected(client)
 
     def check_origin(self, origin) -> bool:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -166,6 +166,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         hm_protocol (Optional[HiveMindListenerProtocol]): The protocol instance for handling HiveMind messages.
     """
     hm_protocol = None
+    source_ip: Optional[str] = None
 
     def _client_ip(self) -> Optional[str]:
         return resolve_client_ip(
@@ -194,7 +195,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
 
     def on_message(self, message: str) -> None:
         message = self.client.decode(message)
-        peer = self._peer_label(self.client)
+        peer = self._peer_label(self.client.peer)
         if (
                 message.msg_type == HiveMessageType.BUS
                 and message.payload.msg_type == "recognizer_loop:b64_audio"
@@ -204,28 +205,26 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             LOG.info(f"Received {peer} message: {message}")
         self.hm_protocol.handle_message(message, self.client)
 
-    @staticmethod
-    def _peer_label(client: HiveMindClientConnection) -> str:
-        ip = getattr(client, "source_ip", None)
-        return f"{client.peer} ({ip})" if ip else client.peer
+    def _peer_label(self, peer: str) -> str:
+        return f"{peer} ({self.source_ip})" if self.source_ip else peer
 
     def open(self) -> None:
         """
         Handle a new client connection and perform authorization.
         """
-        source_ip = self._client_ip()
+        self.source_ip = self._client_ip()
         auth = self.get_query_argument("authorization", None)
         try:
             useragent, key = self.decode_auth(auth)
         except (ValueError, UnicodeDecodeError) as e:
             LOG.warning(
-                f"rejecting websocket from {source_ip or self.request.remote_ip}: "
+                f"rejecting websocket from {self.source_ip or self.request.remote_ip}: "
                 f"bad authorization ({e.__class__.__name__}: {e}) "
                 f"raw={auth!r}"
             )
             self.close(code=1008, reason="invalid authorization")
             return
-        LOG.info(f"Authorizing client from {source_ip or 'unknown'} - {useragent}:{key}")
+        LOG.info(f"Authorizing client from {self.source_ip or 'unknown'} - {useragent}:{key}")
 
         def do_send(payload: str, is_bin: bool):
             self.loop.install()  # TODO is this needed?
@@ -243,7 +242,6 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             name=useragent,
             hm_protocol=self.hm_protocol
         )
-        self.client.source_ip = source_ip
         self.hm_protocol.db.sync()
         user: Client = self.hm_protocol.db.get_client_by_api_key(key)
 
@@ -294,7 +292,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
                 f"(no client was ever attached)"
             )
             return
-        LOG.info(f"disconnecting client: {self._peer_label(client)}")
+        LOG.info(f"disconnecting client: {self._peer_label(client.peer)}")
         self.hm_protocol.handle_client_disconnected(client)
 
     def check_origin(self, origin) -> bool:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -64,14 +64,18 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
         HiveMindTornadoWebSocket.loop = ioloop.IOLoop.current()
         HiveMindTornadoWebSocket.hm_protocol = self.hm_protocol
 
-        proxy_cidrs = self.config.get("trusted_proxy_cidrs") or os.getenv(
-            "HIVEMIND_TRUSTED_PROXY_CIDRS"
-        )
-        client_ip_headers = (
-            self.config.get("trusted_client_ip_headers")
-            or os.getenv("HIVEMIND_TRUSTED_CLIENT_IP_HEADERS")
-            or DEFAULT_TRUSTED_HEADERS
-        )
+        if "trusted_proxy_cidrs" in self.config:
+            proxy_cidrs = self.config["trusted_proxy_cidrs"]
+        else:
+            proxy_cidrs = os.getenv("HIVEMIND_TRUSTED_PROXY_CIDRS")
+
+        if "trusted_client_ip_headers" in self.config:
+            client_ip_headers = self.config["trusted_client_ip_headers"]
+        else:
+            client_ip_headers = (
+                os.getenv("HIVEMIND_TRUSTED_CLIENT_IP_HEADERS")
+                or DEFAULT_TRUSTED_HEADERS
+            )
         trusted_networks = parse_networks(_split_csv(proxy_cidrs))
         trusted_headers = tuple(h.lower() for h in _split_csv(client_ip_headers))
 

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -201,7 +201,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         self.hm_protocol.handle_message(message, self.client)
 
     @staticmethod
-    def _peer_label(client) -> str:
+    def _peer_label(client: HiveMindClientConnection) -> str:
         ip = getattr(client, "source_ip", None)
         return f"{client.peer} ({ip})" if ip else client.peer
 

--- a/hivemind_websocket_protocol/_client_ip.py
+++ b/hivemind_websocket_protocol/_client_ip.py
@@ -44,7 +44,16 @@ def resolve_client_ip(
         raw = headers.get(header)
         if not raw:
             continue
-        candidates = [v.strip() for v in raw.split(",") if v.strip()]
+        candidates = []
+        for value in raw.split(","):
+            value = value.strip()
+            if not value:
+                continue
+            try:
+                ipaddress.ip_address(value)
+            except ValueError:
+                continue  # skip "unknown", port-suffixed, garbage
+            candidates.append(value)
         for candidate in reversed(candidates):
             if not _in_networks(candidate, trusted_networks):
                 return candidate

--- a/hivemind_websocket_protocol/_client_ip.py
+++ b/hivemind_websocket_protocol/_client_ip.py
@@ -1,10 +1,10 @@
 """Client-IP resolution for listeners running behind a trusted proxy."""
 import ipaddress
-from typing import Iterable, Mapping, Optional, Tuple
+from typing import Iterable, Mapping, Optional, Tuple, Union
 
 from ovos_utils.log import LOG
 
-IPNetwork = ipaddress._BaseNetwork
+IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 
 
 def parse_networks(cidrs: Iterable[str]) -> Tuple[IPNetwork, ...]:

--- a/hivemind_websocket_protocol/_client_ip.py
+++ b/hivemind_websocket_protocol/_client_ip.py
@@ -1,0 +1,51 @@
+"""Client-IP resolution for listeners running behind a trusted proxy."""
+import ipaddress
+from typing import Iterable, Mapping, Optional, Tuple
+
+from ovos_utils.log import LOG
+
+IPNetwork = ipaddress._BaseNetwork
+
+
+def parse_networks(cidrs: Iterable[str]) -> Tuple[IPNetwork, ...]:
+    nets = []
+    for cidr in cidrs:
+        try:
+            nets.append(ipaddress.ip_network(cidr, strict=False))
+        except ValueError:
+            LOG.warning(f"hivemind: ignoring invalid trusted proxy CIDR: {cidr!r}")
+    return tuple(nets)
+
+
+def _in_networks(ip: str, networks: Tuple[IPNetwork, ...]) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return any(addr in net for net in networks)
+
+
+def resolve_client_ip(
+    remote_ip: Optional[str],
+    headers: Mapping[str, str],
+    trusted_networks: Tuple[IPNetwork, ...],
+    trusted_headers: Tuple[str, ...],
+) -> Optional[str]:
+    """Return the real client IP.
+
+    Headers are only consulted when the direct peer is in a trusted proxy CIDR.
+    For chains (comma-separated values, e.g. X-Forwarded-For), walk right-to-left
+    and return the first address that is not itself a trusted proxy.
+    """
+    if not remote_ip or not _in_networks(remote_ip, trusted_networks):
+        return remote_ip
+
+    for header in trusted_headers:
+        raw = headers.get(header)
+        if not raw:
+            continue
+        candidates = [v.strip() for v in raw.split(",") if v.strip()]
+        for candidate in reversed(candidates):
+            if not _in_networks(candidate, trusted_networks):
+                return candidate
+    return remote_ip

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -68,27 +68,17 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
-@pytest.fixture
-def tornado_server():
-    """Run HiveMindWebsocketProtocol on a real Tornado server in a thread.
+def _spawn_tornado(trusted_networks=(), trusted_headers=()):
+    """Helper: spin up HiveMindWebsocketProtocol on a real Tornado server.
 
-    Yields a `TornadoServer` carrying host/port/api_key/password/master. The
-    server is torn down after the test by stopping the ioloop.
-
-    Only one Tornado server can run per process at a time because the handler
-    keeps `loop`/`hm_protocol` as class attributes — pytest's default
-    function-scope serialises that for us.
+    Returns `(TornadoServer, thread)`. Caller is responsible for teardown:
+    schedule `HiveMindTornadoWebSocket.loop.add_callback(loop.stop)` and
+    join the thread.
     """
     api_key = "test-api-key"
     password = "test-password"
 
-    # Borrow hivescope's wiring for db / agent / binary protocols, then
-    # point our Tornado server at its hm_protocol.
-    master = MasterNode.create(
-        "M0",
-        require_crypto=False,
-        handshake_enabled=True,
-    )
+    master = MasterNode.create("M0", require_crypto=False, handshake_enabled=True)
     master.register_satellite(
         api_key,
         password=password,
@@ -113,7 +103,11 @@ def tornado_server():
             loop.make_current()
             HiveMindTornadoWebSocket.loop = loop
             HiveMindTornadoWebSocket.hm_protocol = master.hm_protocol
-            app = web.Application([("/", HiveMindTornadoWebSocket)])
+            app = web.Application(
+                [("/", HiveMindTornadoWebSocket)],
+                trusted_networks=trusted_networks,
+                trusted_headers=trusted_headers,
+            )
             app.listen(port, "127.0.0.1")
             loop.add_callback(server_ready.set)
             loop.start()
@@ -127,13 +121,44 @@ def tornado_server():
         raise RuntimeError("Tornado server failed to start within 5s")
     if server_error:
         raise server_error[0]
-    time.sleep(0.05)  # let listen() finish binding before first client
+    time.sleep(0.05)
+    server = TornadoServer(host="127.0.0.1", port=port,
+                           api_key=api_key, password=password, master=master)
+    return server, thread
 
+
+def _teardown_tornado(thread):
+    loop = HiveMindTornadoWebSocket.loop
+    if loop is not None:
+        loop.add_callback(loop.stop)
+    thread.join(timeout=5.0)
+
+
+@pytest.fixture
+def tornado_server():
+    """Plain Tornado server, no trusted-proxy config."""
+    server, thread = _spawn_tornado()
     try:
-        yield TornadoServer(host="127.0.0.1", port=port,
-                            api_key=api_key, password=password, master=master)
+        yield server
     finally:
-        loop = HiveMindTornadoWebSocket.loop
-        if loop is not None:
-            loop.add_callback(loop.stop)
-        thread.join(timeout=5.0)
+        _teardown_tornado(thread)
+
+
+@pytest.fixture
+def tornado_server_with_proxy():
+    """Tornado server with 127.0.0.0/8 as a trusted proxy CIDR.
+
+    Tests use this to send X-Forwarded-For / X-Real-IP from the local
+    client (which IS in 127.0.0.0/8) and assert the listener resolves
+    the forwarded address.
+    """
+    from hivemind_websocket_protocol._client_ip import parse_networks
+    networks = parse_networks(["127.0.0.0/8"])
+    headers = ("x-forwarded-for", "x-real-ip")
+    server, thread = _spawn_tornado(
+        trusted_networks=networks, trusted_headers=headers,
+    )
+    try:
+        yield server
+    finally:
+        _teardown_tornado(thread)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -71,9 +71,8 @@ def _free_port() -> int:
 def _spawn_tornado(trusted_networks=(), trusted_headers=()):
     """Helper: spin up HiveMindWebsocketProtocol on a real Tornado server.
 
-    Returns `(TornadoServer, thread)`. Caller is responsible for teardown:
-    schedule `HiveMindTornadoWebSocket.loop.add_callback(loop.stop)` and
-    join the thread.
+    Returns `(TornadoServer, thread, loop)`. Caller is responsible for
+    teardown via `_teardown_tornado(thread, loop)`.
     """
     api_key = "test-api-key"
     password = "test-password"
@@ -92,6 +91,7 @@ def _spawn_tornado(trusted_networks=(), trusted_headers=()):
     port = _free_port()
     server_ready = threading.Event()
     server_error = []
+    loop_ref = []
 
     def _run():
         try:
@@ -101,6 +101,7 @@ def _spawn_tornado(trusted_networks=(), trusted_headers=()):
             asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
             loop = ioloop.IOLoop()
             loop.make_current()
+            loop_ref.append(loop)
             HiveMindTornadoWebSocket.loop = loop
             HiveMindTornadoWebSocket.hm_protocol = master.hm_protocol
             app = web.Application(
@@ -124,11 +125,11 @@ def _spawn_tornado(trusted_networks=(), trusted_headers=()):
     time.sleep(0.05)
     server = TornadoServer(host="127.0.0.1", port=port,
                            api_key=api_key, password=password, master=master)
-    return server, thread
+    return server, thread, loop_ref[0]
 
 
-def _teardown_tornado(thread):
-    loop = HiveMindTornadoWebSocket.loop
+def _teardown_tornado(thread, loop):
+    """Stop the specific IOLoop this spawn created and join its thread."""
     if loop is not None:
         loop.add_callback(loop.stop)
     thread.join(timeout=5.0)
@@ -137,11 +138,11 @@ def _teardown_tornado(thread):
 @pytest.fixture
 def tornado_server():
     """Plain Tornado server, no trusted-proxy config."""
-    server, thread = _spawn_tornado()
+    server, thread, loop = _spawn_tornado()
     try:
         yield server
     finally:
-        _teardown_tornado(thread)
+        _teardown_tornado(thread, loop)
 
 
 @pytest.fixture
@@ -155,10 +156,10 @@ def tornado_server_with_proxy():
     from hivemind_websocket_protocol._client_ip import parse_networks
     networks = parse_networks(["127.0.0.0/8"])
     headers = ("x-forwarded-for", "x-real-ip")
-    server, thread = _spawn_tornado(
+    server, thread, loop = _spawn_tornado(
         trusted_networks=networks, trusted_headers=headers,
     )
     try:
         yield server
     finally:
-        _teardown_tornado(thread)
+        _teardown_tornado(thread, loop)

--- a/tests/e2e/test_trusted_proxy_e2e.py
+++ b/tests/e2e/test_trusted_proxy_e2e.py
@@ -1,0 +1,161 @@
+"""End-to-end: trusted-proxy IP resolution over real WebSocket.
+
+Uses the `tornado_server_with_proxy` fixture which configures
+`127.0.0.0/8` as a trusted proxy CIDR. The test client (also on
+127.0.0.1) is in that range, so X-Forwarded-For headers it sends are
+honoured. A plain `tornado_server` (no trusted CIDRs) is used as the
+negative control.
+"""
+import time
+
+import pytest
+import websocket as ws_client
+import pybase64
+
+from hivemind_websocket_protocol import HiveMindTornadoWebSocket
+
+
+# --- helpers --------------------------------------------------------------
+
+def _capture_source_ip():
+    """Monkey-patch the handler's _client_ip to record what it resolves.
+
+    Returns `(values_list, restore_fn)`. Tests call restore_fn() in a
+    finally block.
+    """
+    captured = []
+    original = HiveMindTornadoWebSocket._client_ip
+
+    def _spy(self):
+        value = original(self)
+        captured.append(value)
+        return value
+
+    HiveMindTornadoWebSocket._client_ip = _spy
+    return captured, lambda: setattr(HiveMindTornadoWebSocket, "_client_ip", original)
+
+
+def _auth_url(server, useragent="e2e"):
+    raw = f"{useragent}:{server.api_key}"
+    b64 = pybase64.b64encode(raw.encode()).decode()
+    return f"{server.url}/?authorization={b64}"
+
+
+def _connect(url, *, headers=None, timeout=3):
+    sock = ws_client.create_connection(url, header=headers or [], timeout=timeout)
+    sock.settimeout(1)
+    # Drain HELLO so the server-side handler has fully entered open()
+    try:
+        sock.recv()
+    except Exception:
+        pass
+    return sock
+
+
+# --- behaviour tests ------------------------------------------------------
+
+def test_x_forwarded_for_resolves_to_client(tornado_server_with_proxy):
+    """When the peer is in a trusted CIDR, XFF is consulted."""
+    captured, restore = _capture_source_ip()
+    try:
+        sock = _connect(
+            _auth_url(tornado_server_with_proxy),
+            headers=["X-Forwarded-For: 8.8.8.8"],
+        )
+        sock.close()
+        time.sleep(0.1)
+        assert "8.8.8.8" in captured, \
+            f"expected 8.8.8.8 from X-Forwarded-For, got {captured!r}"
+    finally:
+        restore()
+
+
+def test_xff_chain_walks_right_to_left(tornado_server_with_proxy):
+    """A chain with the real client leftmost; intermediate is trusted."""
+    captured, restore = _capture_source_ip()
+    try:
+        sock = _connect(
+            _auth_url(tornado_server_with_proxy),
+            headers=["X-Forwarded-For: 8.8.8.8, 127.0.0.5"],
+        )
+        sock.close()
+        time.sleep(0.1)
+        # Right-to-left: 127.0.0.5 is trusted -> skip; 8.8.8.8 wins.
+        assert "8.8.8.8" in captured
+    finally:
+        restore()
+
+
+def test_x_real_ip_used_when_xff_missing(tornado_server_with_proxy):
+    captured, restore = _capture_source_ip()
+    try:
+        sock = _connect(
+            _auth_url(tornado_server_with_proxy),
+            headers=["X-Real-IP: 4.4.4.4"],
+        )
+        sock.close()
+        time.sleep(0.1)
+        assert "4.4.4.4" in captured
+    finally:
+        restore()
+
+
+def test_xff_preferred_over_x_real_ip(tornado_server_with_proxy):
+    captured, restore = _capture_source_ip()
+    try:
+        sock = _connect(
+            _auth_url(tornado_server_with_proxy),
+            headers=["X-Forwarded-For: 8.8.8.8", "X-Real-IP: 4.4.4.4"],
+        )
+        sock.close()
+        time.sleep(0.1)
+        assert "8.8.8.8" in captured
+    finally:
+        restore()
+
+
+def test_no_forwarded_header_falls_back_to_remote_ip(tornado_server_with_proxy):
+    captured, restore = _capture_source_ip()
+    try:
+        sock = _connect(_auth_url(tornado_server_with_proxy))
+        sock.close()
+        time.sleep(0.1)
+        assert any(ip == "127.0.0.1" for ip in captured), \
+            f"expected 127.0.0.1 fallback, got {captured!r}"
+    finally:
+        restore()
+
+
+def test_malformed_xff_falls_back_to_remote_ip(tornado_server_with_proxy):
+    """RFC 7239 'unknown' or garbage tokens are skipped."""
+    captured, restore = _capture_source_ip()
+    try:
+        sock = _connect(
+            _auth_url(tornado_server_with_proxy),
+            headers=["X-Forwarded-For: unknown"],
+        )
+        sock.close()
+        time.sleep(0.1)
+        # Falls back to the actual remote peer
+        assert any(ip == "127.0.0.1" for ip in captured)
+    finally:
+        restore()
+
+
+# --- negative control: feature off ---------------------------------------
+
+def test_xff_ignored_when_no_trusted_cidrs(tornado_server):
+    """Without trusted CIDRs, XFF must be ignored entirely."""
+    captured, restore = _capture_source_ip()
+    try:
+        sock = _connect(
+            _auth_url(tornado_server),
+            headers=["X-Forwarded-For: 8.8.8.8"],
+        )
+        sock.close()
+        time.sleep(0.1)
+        assert "8.8.8.8" not in captured, \
+            "XFF must not be trusted when no proxy CIDRs configured"
+        assert any(ip == "127.0.0.1" for ip in captured)
+    finally:
+        restore()

--- a/tests/e2e/test_trusted_proxy_e2e.py
+++ b/tests/e2e/test_trusted_proxy_e2e.py
@@ -6,9 +6,9 @@ Uses the `tornado_server_with_proxy` fixture which configures
 honoured. A plain `tornado_server` (no trusted CIDRs) is used as the
 negative control.
 """
+import socket
 import time
 
-import pytest
 import websocket as ws_client
 import pybase64
 
@@ -44,10 +44,12 @@ def _auth_url(server, useragent="e2e"):
 def _connect(url, *, headers=None, timeout=3):
     sock = ws_client.create_connection(url, header=headers or [], timeout=timeout)
     sock.settimeout(1)
-    # Drain HELLO so the server-side handler has fully entered open()
+    # Drain HELLO so the server-side handler has fully entered open().
+    # The recv may legitimately time out if the server hasn't pushed yet;
+    # any other error is a real failure.
     try:
         sock.recv()
-    except Exception:
+    except (ws_client.WebSocketTimeoutException, socket.timeout):
         pass
     return sock
 

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -62,3 +62,156 @@ def test_ipv6_trusted_chain():
     trusted = parse_networks(["fd00::/8"])
     headers = {"x-forwarded-for": "2001:db8::1, fd00::5"}
     assert resolve_client_ip("fd00::5", headers, trusted, HEADERS) == "2001:db8::1"
+
+
+# --- Header precedence ---------------------------------------------------
+
+def test_xff_preferred_over_real_ip_when_both_present():
+    headers = {"x-forwarded-for": "8.8.8.8", "x-real-ip": "9.9.9.9"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_falls_through_to_real_ip_when_xff_all_trusted():
+    headers = {"x-forwarded-for": "10.0.0.1, 192.168.1.1", "x-real-ip": "9.9.9.9"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "9.9.9.9"
+
+
+def test_header_order_respects_config_tuple():
+    headers = {"x-forwarded-for": "8.8.8.8", "x-real-ip": "9.9.9.9"}
+    reordered = ("x-real-ip", "x-forwarded-for")
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, reordered) == "9.9.9.9"
+
+
+def test_empty_trusted_headers_falls_back_to_remote():
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, ()) == "10.0.0.5"
+
+
+# --- Chain parsing -------------------------------------------------------
+
+def test_single_ip_no_chain():
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_chain_with_extra_whitespace():
+    headers = {"x-forwarded-for": "  8.8.8.8 ,   192.168.1.1  ,  10.0.0.5  "}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_chain_with_empty_entries():
+    headers = {"x-forwarded-for": "8.8.8.8,,,10.0.0.5"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_chain_with_trailing_comma():
+    headers = {"x-forwarded-for": "8.8.8.8,"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+# --- CIDR boundaries -----------------------------------------------------
+
+def test_cidr_lower_boundary_inclusive():
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("10.0.0.0", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_cidr_upper_boundary_inclusive():
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("10.255.255.255", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_just_outside_cidr_not_trusted():
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    # 11.0.0.0 is outside 10.0.0.0/8
+    assert resolve_client_ip("11.0.0.0", headers, TRUSTED, HEADERS) == "11.0.0.0"
+
+
+def test_single_host_cidr():
+    trusted = parse_networks(["172.16.0.1/32"])
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("172.16.0.1", headers, trusted, HEADERS) == "8.8.8.8"
+    assert resolve_client_ip("172.16.0.2", headers, trusted, HEADERS) == "172.16.0.2"
+
+
+def test_loopback_not_trusted_by_default():
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("127.0.0.1", headers, TRUSTED, HEADERS) == "127.0.0.1"
+
+
+# --- IPv6 / mixed --------------------------------------------------------
+
+def test_ipv6_peer_with_ipv4_chain():
+    trusted = parse_networks(["fd00::/8", "10.0.0.0/8"])
+    headers = {"x-forwarded-for": "8.8.8.8, 10.0.0.5"}
+    assert resolve_client_ip("fd00::5", headers, trusted, HEADERS) == "8.8.8.8"
+
+
+def test_ipv4_peer_with_ipv6_chain():
+    trusted = parse_networks(["10.0.0.0/8", "fd00::/8"])
+    headers = {"x-forwarded-for": "2001:db8::1, fd00::5"}
+    assert resolve_client_ip("10.0.0.5", headers, trusted, HEADERS) == "2001:db8::1"
+
+
+def test_ipv6_loopback_not_trusted_by_default():
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("::1", headers, TRUSTED, HEADERS) == "::1"
+
+
+def test_ipv6_compressed_form_normalized_by_ipaddress():
+    # 2001:db8:0:0::1 collapses to 2001:db8::1 inside the trust check
+    trusted = parse_networks(["2001:db8::/32"])
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("2001:db8:0:0:0:0:0:5", headers, trusted, HEADERS) == "8.8.8.8"
+
+
+# --- Misc / defensive ----------------------------------------------------
+
+def test_empty_string_remote_ip():
+    assert resolve_client_ip("", {}, TRUSTED, HEADERS) == ""
+
+
+def test_malformed_remote_ip():
+    # garbage peer can't be in any network -> headers ignored, returned as-is
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("not-an-ip", headers, TRUSTED, HEADERS) == "not-an-ip"
+
+
+def test_port_suffixed_xff_returned_verbatim():
+    # We don't normalize header values; if a proxy appends a port, it's on them.
+    # Documenting actual behaviour so a future change is intentional.
+    headers = {"x-forwarded-for": "8.8.8.8:443"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8:443"
+
+
+def test_overlapping_cidrs():
+    # smaller range nested in larger; both treated as trusted
+    trusted = parse_networks(["10.0.0.0/8", "10.1.0.0/16"])
+    headers = {"x-forwarded-for": "8.8.8.8, 10.1.0.1, 10.2.0.1"}
+    assert resolve_client_ip("10.0.0.5", headers, trusted, HEADERS) == "8.8.8.8"
+
+
+def test_long_chain():
+    chain = ", ".join(["10.0.0." + str(i) for i in range(1, 20)] + ["8.8.8.8"][::-1])
+    # 19 trusted hops then one client (leftmost)
+    chain = "8.8.8.8, " + ", ".join("10.0.0." + str(i) for i in range(1, 20))
+    headers = {"x-forwarded-for": chain}
+    assert resolve_client_ip("10.0.0.20", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_parse_networks_accepts_host_bits_set():
+    # strict=False allows 10.0.0.5/8 -> 10.0.0.0/8
+    nets = parse_networks(["10.0.0.5/8"])
+    assert len(nets) == 1
+    assert str(nets[0]) == "10.0.0.0/8"
+
+
+def test_parse_networks_empty():
+    assert parse_networks([]) == ()
+
+
+def test_parse_networks_skips_blank_strings():
+    # Real-world: env var with empty value
+    nets = parse_networks(["10.0.0.0/8", "", "  "])
+    # ip_network rejects "" and "  " -> warnings, but we get the valid one
+    assert len(nets) == 1

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -43,10 +43,25 @@ def test_falls_back_to_next_header_when_first_missing():
 
 
 def test_bad_ip_in_header_is_skipped():
-    # bad value is not in any network, so it's returned as-is
-    # (we trust upstream proxies; validation is their job)
+    # malformed tokens are filtered; fall back to remote_ip
     headers = {"x-forwarded-for": "not-an-ip"}
-    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "not-an-ip"
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "10.0.0.5"
+
+
+def test_unknown_token_skipped_per_rfc7239():
+    headers = {"x-forwarded-for": "unknown"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "10.0.0.5"
+
+
+def test_mixed_valid_and_invalid_tokens():
+    headers = {"x-forwarded-for": "unknown, 8.8.8.8, garbage"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_invalid_token_between_trusted_and_client():
+    # garbage in the middle should not derail the right-to-left walk
+    headers = {"x-forwarded-for": "8.8.8.8, garbage, 10.0.0.5"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
 
 
 def test_empty_header_falls_back():
@@ -177,11 +192,11 @@ def test_malformed_remote_ip():
     assert resolve_client_ip("not-an-ip", headers, TRUSTED, HEADERS) == "not-an-ip"
 
 
-def test_port_suffixed_xff_returned_verbatim():
-    # We don't normalize header values; if a proxy appends a port, it's on them.
-    # Documenting actual behaviour so a future change is intentional.
+def test_port_suffixed_xff_is_skipped():
+    # ip_address() rejects "1.2.3.4:port"; we don't try to strip ports.
+    # A misconfigured proxy that appends ports falls through to remote_ip.
     headers = {"x-forwarded-for": "8.8.8.8:443"}
-    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8:443"
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "10.0.0.5"
 
 
 def test_overlapping_cidrs():
@@ -215,3 +230,33 @@ def test_parse_networks_skips_blank_strings():
     nets = parse_networks(["10.0.0.0/8", "", "  "])
     # ip_network rejects "" and "  " -> warnings, but we get the valid one
     assert len(nets) == 1
+
+
+# --- _split_csv (config / env parsing) -----------------------------------
+
+def test_split_csv_handles_string_list_none():
+    from hivemind_websocket_protocol import _split_csv
+
+    assert _split_csv(None) == ()
+    assert _split_csv("") == ()
+    assert _split_csv("a,b,c") == ("a", "b", "c")
+    assert _split_csv("  a , , b  ") == ("a", "b")
+    assert _split_csv(["a", "b"]) == ("a", "b")
+    assert _split_csv(("a", "", " b ")) == ("a", "b")
+    assert _split_csv([]) == ()
+
+
+def test_explicit_empty_config_overrides_env(monkeypatch):
+    # Regression: 'or' would treat an explicit [] as falsy and fall through to env.
+    # The 'in self.config' branch must let an explicit empty list disable the feature.
+    from hivemind_websocket_protocol import _split_csv
+
+    config = {"trusted_proxy_cidrs": []}
+    monkeypatch.setenv("HIVEMIND_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+
+    import os
+    if "trusted_proxy_cidrs" in config:
+        value = config["trusted_proxy_cidrs"]
+    else:
+        value = os.getenv("HIVEMIND_TRUSTED_PROXY_CIDRS")
+    assert _split_csv(value) == ()  # explicit empty list wins over env

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -1,0 +1,64 @@
+from hivemind_websocket_protocol._client_ip import (
+    parse_networks,
+    resolve_client_ip,
+)
+
+
+TRUSTED = parse_networks(["10.0.0.0/8", "192.168.0.0/16"])
+HEADERS = ("x-forwarded-for", "x-real-ip")
+
+
+def test_parse_networks_skips_invalid():
+    nets = parse_networks(["10.0.0.0/8", "not-a-cidr", "192.168.0.0/16"])
+    assert len(nets) == 2
+
+
+def test_returns_remote_ip_when_no_trusted_networks():
+    assert resolve_client_ip("1.2.3.4", {}, (), HEADERS) == "1.2.3.4"
+
+
+def test_returns_remote_ip_when_peer_not_trusted():
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("1.2.3.4", headers, TRUSTED, HEADERS) == "1.2.3.4"
+
+
+def test_trusted_peer_uses_xff_header():
+    headers = {"x-forwarded-for": "8.8.8.8"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_xff_chain_walked_right_to_left_skipping_trusted():
+    headers = {"x-forwarded-for": "8.8.8.8, 192.168.1.1, 10.0.0.5"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_xff_chain_all_trusted_falls_back_to_remote():
+    headers = {"x-forwarded-for": "10.0.0.5, 192.168.1.1"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "10.0.0.5"
+
+
+def test_falls_back_to_next_header_when_first_missing():
+    headers = {"x-real-ip": "8.8.8.8"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "8.8.8.8"
+
+
+def test_bad_ip_in_header_is_skipped():
+    # bad value is not in any network, so it's returned as-is
+    # (we trust upstream proxies; validation is their job)
+    headers = {"x-forwarded-for": "not-an-ip"}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "not-an-ip"
+
+
+def test_empty_header_falls_back():
+    headers = {"x-forwarded-for": "   "}
+    assert resolve_client_ip("10.0.0.5", headers, TRUSTED, HEADERS) == "10.0.0.5"
+
+
+def test_none_remote_ip():
+    assert resolve_client_ip(None, {}, TRUSTED, HEADERS) is None
+
+
+def test_ipv6_trusted_chain():
+    trusted = parse_networks(["fd00::/8"])
+    headers = {"x-forwarded-for": "2001:db8::1, fd00::5"}
+    assert resolve_client_ip("fd00::5", headers, trusted, HEADERS) == "2001:db8::1"

--- a/tests/test_trusted_proxy_config.py
+++ b/tests/test_trusted_proxy_config.py
@@ -1,0 +1,142 @@
+"""Integration tests for trusted-proxy config loading in run().
+
+Exercises the precedence rules:
+- config dict key takes precedence over env var
+- env var takes precedence over default
+- explicit empty config list disables the feature (regression for the
+  `or`-vs-`in self.config` fix)
+"""
+import asyncio
+import threading
+import time
+
+import pytest
+from tornado.platform.asyncio import AnyThreadEventLoopPolicy
+
+from hivemind_websocket_protocol import (
+    HiveMindTornadoWebSocket,
+    HiveMindWebsocketProtocol,
+)
+from hivescope.node import MasterNode
+
+from tests.test_protocol_unit import _free_port  # noqa: reuse
+
+
+def _run_until_settings_loaded(proto):
+    """Start proto.run() in a thread, wait for the Application to install
+    its settings, then stop the loop and return the settings dict."""
+    if hasattr(HiveMindTornadoWebSocket, "loop"):
+        del HiveMindTornadoWebSocket.loop
+
+    started = threading.Event()
+    captured = {}
+
+    def _stop_when_ready():
+        for _ in range(200):
+            loop = getattr(HiveMindTornadoWebSocket, "loop", None)
+            if loop is not None and getattr(loop, "asyncio_loop", None) is not None:
+                # The Application is constructed inside run() right before
+                # listen(). Pull settings from the handler's first registered
+                # app.  We grab it indirectly via the listening HTTPServer.
+                time.sleep(0.1)
+                loop.add_callback(loop.stop)
+                return
+            time.sleep(0.05)
+
+    def _run():
+        asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
+        threading.Thread(target=_stop_when_ready, daemon=True).start()
+        started.set()
+        # Hook into run() — we replace web.Application.listen with a recorder.
+        from tornado import web
+        original_init = web.Application.__init__
+
+        def _spy_init(self, *args, **kwargs):
+            captured.update(kwargs)
+            return original_init(self, *args, **kwargs)
+
+        web.Application.__init__ = _spy_init
+        try:
+            proto.run()
+        finally:
+            web.Application.__init__ = original_init
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    assert started.wait(2)
+    t.join(timeout=5)
+    return captured
+
+
+def _make_proto(config=None):
+    master = MasterNode.create("MC", require_crypto=False, handshake_enabled=True)
+    cfg = {"host": "127.0.0.1", "port": _free_port(), "ssl": False}
+    if config:
+        cfg.update(config)
+    return HiveMindWebsocketProtocol(config=cfg, hm_protocol=master.hm_protocol)
+
+
+# --- precedence rules ----------------------------------------------------
+
+def test_config_proxy_cidrs_overrides_env(monkeypatch):
+    monkeypatch.setenv("HIVEMIND_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+    proto = _make_proto({"trusted_proxy_cidrs": "192.168.0.0/16"})
+    settings = _run_until_settings_loaded(proto)
+    networks = settings["trusted_networks"]
+    assert len(networks) == 1
+    assert str(networks[0]) == "192.168.0.0/16"
+
+
+def test_env_used_when_config_absent(monkeypatch):
+    monkeypatch.setenv("HIVEMIND_TRUSTED_PROXY_CIDRS", "10.0.0.0/8,172.16.0.0/12")
+    proto = _make_proto()
+    settings = _run_until_settings_loaded(proto)
+    assert len(settings["trusted_networks"]) == 2
+
+
+def test_explicit_empty_config_disables_feature(monkeypatch):
+    """Regression: 'or' would have leaked env into an explicit empty list."""
+    monkeypatch.setenv("HIVEMIND_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+    proto = _make_proto({"trusted_proxy_cidrs": []})
+    settings = _run_until_settings_loaded(proto)
+    assert settings["trusted_networks"] == ()
+
+
+def test_default_headers_used_when_nothing_configured():
+    proto = _make_proto()
+    settings = _run_until_settings_loaded(proto)
+    assert settings["trusted_headers"] == ("x-forwarded-for", "x-real-ip")
+
+
+def test_config_headers_override_default():
+    proto = _make_proto({"trusted_client_ip_headers": "x-custom-ip"})
+    settings = _run_until_settings_loaded(proto)
+    assert settings["trusted_headers"] == ("x-custom-ip",)
+
+
+def test_env_headers_used_when_config_absent(monkeypatch):
+    monkeypatch.setenv("HIVEMIND_TRUSTED_CLIENT_IP_HEADERS", "x-real-ip")
+    proto = _make_proto()
+    settings = _run_until_settings_loaded(proto)
+    assert settings["trusted_headers"] == ("x-real-ip",)
+
+
+def test_explicit_empty_headers_disables_feature(monkeypatch):
+    monkeypatch.setenv("HIVEMIND_TRUSTED_CLIENT_IP_HEADERS", "x-from-env")
+    proto = _make_proto({"trusted_client_ip_headers": []})
+    settings = _run_until_settings_loaded(proto)
+    assert settings["trusted_headers"] == ()
+
+
+def test_headers_are_lowercased():
+    proto = _make_proto({"trusted_client_ip_headers": "X-Forwarded-For,X-Real-IP"})
+    settings = _run_until_settings_loaded(proto)
+    assert settings["trusted_headers"] == ("x-forwarded-for", "x-real-ip")
+
+
+def test_invalid_cidrs_are_skipped_not_raised():
+    proto = _make_proto({
+        "trusted_proxy_cidrs": "10.0.0.0/8,not-a-cidr,192.168.0.0/16",
+    })
+    settings = _run_until_settings_loaded(proto)
+    assert len(settings["trusted_networks"]) == 2

--- a/tests/test_trusted_proxy_config.py
+++ b/tests/test_trusted_proxy_config.py
@@ -10,7 +10,6 @@ import asyncio
 import threading
 import time
 
-import pytest
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
 from hivemind_websocket_protocol import (
@@ -19,7 +18,7 @@ from hivemind_websocket_protocol import (
 )
 from hivescope.node import MasterNode
 
-from tests.test_protocol_unit import _free_port  # noqa: reuse
+from tests.test_protocol_unit import _free_port
 
 
 def _run_until_settings_loaded(proto):
@@ -102,7 +101,9 @@ def test_explicit_empty_config_disables_feature(monkeypatch):
     assert settings["trusted_networks"] == ()
 
 
-def test_default_headers_used_when_nothing_configured():
+def test_default_headers_used_when_nothing_configured(monkeypatch):
+    monkeypatch.delenv("HIVEMIND_TRUSTED_CLIENT_IP_HEADERS", raising=False)
+    monkeypatch.delenv("HIVEMIND_TRUSTED_PROXY_CIDRS", raising=False)
     proto = _make_proto()
     settings = _run_until_settings_loaded(proto)
     assert settings["trusted_headers"] == ("x-forwarded-for", "x-real-ip")


### PR DESCRIPTION
Supersedes #14 and refs #13.

Same feature as #14 — when the listener runs behind a reverse proxy, resolve the real client IP from a trusted header — but rewritten in a simpler style and with unit tests. Default behaviour is unchanged when not configured.

## What's different from #14

- IP resolution lives in a small pure function in `hivemind_websocket_protocol/_client_ip.py` instead of nine helper methods on the handler.
- Trusted CIDRs / headers are passed via Tornado `Application` settings rather than patched onto the handler class from `run()`.
- Drops:
  - dead `is_global_ip` branch (both arms returned the same value)
  - speculative RFC 7239 `Forwarded` header parsing — `X-Forwarded-For` / `X-Real-IP` cover the common cases; add `Forwarded` later if needed.
  - hand-rolled query string parser (use Tornado's `get_query_argument`)
  - over-defensive coercion of config values and header values
- Adds `tests/test_client_ip.py` — 11 unit tests.
- Drops the `decode_auth` / `on_close` changes that were part of #14 — those are #12's scope and should land via that PR.

## Config

Identical to #14:

```shell
HIVEMIND_TRUSTED_PROXY_CIDRS=10.42.0.0/16,104.16.0.0/13
HIVEMIND_TRUSTED_CLIENT_IP_HEADERS=x-forwarded-for,x-real-ip
```

Headers are only consulted when the direct peer is in a trusted proxy CIDR. For chains, the listener walks right-to-left and uses the first address that is not in the trusted ranges.

## Test plan
- [x] `pytest tests/test_client_ip.py` — 11 passed
- [ ] Manual smoke behind a reverse proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket server now resolves real client IPs when behind trusted proxies, supports configurable trusted CIDRs and trusted header names, and surfaces resolved IPs in connection and authorization logs.
  * Prefers X-Forwarded-For with right-to-left chain walking, falls back to other headers or remote IP when appropriate; ignores malformed tokens.

* **Tests**
  * Extensive unit and end-to-end tests for proxy scenarios, header precedence, IPv4/IPv6, edge cases, and config vs. environment precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/hivemind-websocket-protocol/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->