### PR TITLE
docs: add /docs/ and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,54 @@
-# HiveMind Websockets protocol
+# HiveMind WebSocket Protocol
 
-Transport HiveMessages via websockets
+WebSocket transport for HiveMind messages. This is the reference network
+protocol implementation; the `hivemind-core` plugin system allows it to be
+replaced with any other transport.
 
-This is the reference implementation of HiveMind, but you can theoretically replace websockets with anything
+## Install
+
+```bash
+pip install hivemind-websocket-protocol
+```
+
+## Quick Start
+
+The package registers itself as a `hivemind.network.protocol` entry-point
+(`hivemind-websocket-plugin`). `hivemind-core` loads it automatically; you do
+not instantiate `HiveMindWebsocketProtocol` directly in normal usage.
+
+## Configuration
+
+Pass a config dict when constructing `HiveMindWebsocketProtocol`, or set the
+corresponding environment variables. Config dict keys take precedence over env
+vars.
+
+### Connection
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `host` | — | `0.0.0.0` | Bind address (falls back to identity `default_master`) |
+| `port` | — | `5678` | Listen port (falls back to identity `default_port`) |
+| `ssl` | — | `false` | Enable TLS (`wss://`). A self-signed cert is generated if none exists. |
+| `cert_dir` | — | `$XDG_DATA_HOME/hivemind` | Directory for TLS cert/key files |
+| `cert_name` | — | `hivemind` | Base name for `<cert_name>.crt` / `<cert_name>.key` |
+
+### Trusted-proxy IP resolution
+
+When HiveMind runs behind a reverse proxy, the real client IP must be read
+from a forwarded header. These options are ignored (headers never consulted)
+unless the direct peer address falls inside a configured CIDR.
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `trusted_proxy_cidrs` | `HIVEMIND_TRUSTED_PROXY_CIDRS` | _(none)_ | Comma-separated CIDRs of trusted proxy addresses |
+| `trusted_client_ip_headers` | `HIVEMIND_TRUSTED_CLIENT_IP_HEADERS` | `x-forwarded-for,x-real-ip` | Ordered list of headers to inspect |
+
+Both config keys accept a string (`"10.0.0.0/8,192.168.0.0/16"`), a list, or
+a tuple. The env vars accept comma-separated strings.
+
+See [docs/configuration.md](docs/configuration.md) for the full reference and
+[docs/architecture.md](docs/architecture.md) for the IP-resolution algorithm.
+
+## License
+
+Apache-2.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,79 @@
+# Architecture
+
+## Transport overview
+
+`HiveMindWebsocketProtocol` is a `NetworkProtocol` plugin loaded by
+`hivemind-core` via the `hivemind.network.protocol` entry-point. Its `run()`
+method (`__init__.py:61`) is the blocking server loop:
+
+1. Resolve config and env vars for proxy CIDRs and trusted headers.
+2. Build a Tornado `Application` with a single route `/ ->
+   HiveMindTornadoWebSocket`, passing `trusted_networks` and
+   `trusted_headers` in `Application.settings`.
+3. Optionally wrap the listener in TLS (self-signed cert auto-generated if
+   absent — `create_self_signed_cert()` at `__init__.py:113`).
+4. Start the `IOLoop` (blocking).
+
+## Handler lifecycle
+
+`HiveMindTornadoWebSocket` (`__init__.py:161`) handles one WebSocket
+connection per instance.
+
+### `open()` — `__init__.py:211`
+
+1. Resolve the real client IP via `_client_ip()` and store it as
+   `self.source_ip`.
+2. Read the `?authorization=` query parameter.
+3. Decode it with `decode_auth()` — Base64, format `name:key` — and close
+   with code `1008` on any decode error.
+4. Look up the API key in `hm_protocol.db`. Close if not found.
+5. Populate `HiveMindClientConnection` with permissions from the database
+   record.
+6. Verify crypto requirements. Close if crypto is required but unavailable.
+7. Call `hm_protocol.handle_new_client()`.
+
+### `on_message()` — `__init__.py:196`
+
+Decodes the frame via `client.decode()`, logs with `_peer_label()`, and
+dispatches to `hm_protocol.handle_message()`.
+
+### `on_close()` — `__init__.py:287`
+
+Guards against connections that never completed `open()` (unauthenticated
+clients where `self.client` was never set), then calls
+`hm_protocol.handle_client_disconnected()`.
+
+## Authorization
+
+Clients connect with a URL query parameter:
+
+```
+ws://host:port/?authorization=<base64(name:key)>
+```
+
+`decode_auth()` (`__init__.py:180`) decodes the Base64 value and splits on
+the first `:`. Both `name` and `key` must be non-empty; otherwise the
+connection is rejected with close code `1008`.
+
+## IP resolution flow
+
+`_client_ip()` (`__init__.py:171`) delegates to `resolve_client_ip()`
+(`_client_ip.py:28`):
+
+1. If `remote_ip` is `None` or not in any `trusted_networks` CIDR, return
+   `remote_ip` unchanged.
+2. Iterate `trusted_headers` in order. For each present header, split the
+   value on commas and walk the list **right-to-left**.
+3. Return the first candidate that is a valid IP address and is **not** in
+   `trusted_networks`.
+4. If all candidates are trusted (or the header is absent/malformed), fall
+   back to `remote_ip`.
+
+IPv4 and IPv6 are both handled. Tokens that are not valid IP addresses
+(e.g. `unknown`, port-suffixed values) are silently skipped per RFC 7239
+intent. `parse_networks()` (`_client_ip.py:10`) uses `strict=False` so host
+bits in a CIDR are silently masked.
+
+`trusted_networks` and `trusted_headers` are passed into the Tornado
+`Application` settings at startup (`__init__.py:90-94`) and read by each
+handler instance via `self.settings`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,61 @@
+# Configuration Reference
+
+Configuration is supplied as a dict to `HiveMindWebsocketProtocol(config={...})`.
+Dict keys always take precedence over environment variables.
+
+## Connection
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `host` | `str` | `0.0.0.0` | Bind address. Falls back to `identity.default_master`. |
+| `port` | `int` | `5678` | Listen port. Falls back to `identity.default_port`. |
+| `ssl` | `bool` | `false` | Enable TLS. |
+| `cert_dir` | `str` | `$XDG_DATA_HOME/hivemind` | Directory for TLS cert and key files. |
+| `cert_name` | `str` | `hivemind` | Base filename; produces `<name>.crt` and `<name>.key`. |
+
+When `ssl=true` and the key file does not exist, a self-signed 2048-bit RSA
+certificate valid for 10 years is generated automatically.
+`HiveMindWebsocketProtocol.create_self_signed_cert()` — `__init__.py:113`
+
+## Trusted-proxy IP resolution
+
+| Key | Env var | Default | Description |
+|---|---|---|---|
+| `trusted_proxy_cidrs` | `HIVEMIND_TRUSTED_PROXY_CIDRS` | _(none — feature disabled)_ | Comma-separated CIDR ranges of trusted proxy addresses. |
+| `trusted_client_ip_headers` | `HIVEMIND_TRUSTED_CLIENT_IP_HEADERS` | `x-forwarded-for,x-real-ip` | Ordered comma-separated list of headers to inspect. |
+
+Both keys accept a `str`, `list`, or `tuple`; env vars accept a
+comma-separated string. The feature is inactive unless at least one CIDR is
+configured — when `trusted_proxy_cidrs` is empty or absent, headers are never
+consulted and the raw `remote_ip` is used as-is.
+
+Supplying an explicit empty list (`trusted_proxy_cidrs: []`) in the config
+dict disables the feature even if the env var is set. The config key presence
+is checked with `in`, not truthiness — `__init__.py:67-70`.
+
+### Header inspection order
+
+Headers in `trusted_client_ip_headers` are inspected left-to-right; the
+first header present with a usable value wins. Within a single
+`X-Forwarded-For` chain the walk is right-to-left (rightmost hop is the
+closest proxy), and the first address that is not itself in a trusted CIDR is
+returned.
+
+See [architecture.md](architecture.md#ip-resolution-flow) for the full
+algorithm.
+
+### Example — nginx reverse proxy on localhost
+
+```bash
+HIVEMIND_TRUSTED_PROXY_CIDRS=127.0.0.1/32
+HIVEMIND_TRUSTED_CLIENT_IP_HEADERS=x-forwarded-for
+```
+
+### Example — internal private network proxies
+
+```python
+config = {
+    "trusted_proxy_cidrs": ["10.0.0.0/8", "192.168.0.0/16"],
+    "trusted_client_ip_headers": ["x-forwarded-for", "x-real-ip"],
+}
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,36 @@
+# Development
+
+## Project layout
+
+```
+hivemind_websocket_protocol/
+    __init__.py          # HiveMindWebsocketProtocol, HiveMindTornadoWebSocket
+    _client_ip.py        # parse_networks(), resolve_client_ip()
+    version.py           # VERSION_MAJOR / MINOR / BUILD / ALPHA constants
+tests/
+    test_client_ip.py    # unit tests for IP resolution logic (~50 cases)
+    test_decode_auth.py  # unit tests for Base64 auth decoding
+    e2e/                 # end-to-end tests (require a running hivemind-core)
+```
+
+## Running tests
+
+```bash
+pip install pytest
+pytest tests/
+```
+
+The unit tests in `test_client_ip.py` and `test_decode_auth.py` have no
+network dependencies and run offline. The `e2e/` suite requires a live
+`hivemind-core` instance.
+
+## Entry-point
+
+The plugin registers under the `hivemind.network.protocol` group:
+
+```
+hivemind-websocket-plugin = hivemind_websocket_protocol:HiveMindWebsocketProtocol
+```
+
+`hivemind-core` discovers and instantiates it automatically via
+`hivemind-plugin-manager`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+# hivemind-websocket-protocol
+
+WebSocket transport for HiveMind messages.
+
+## Overview
+
+Provides a Tornado-based WebSocket server that connects `hivemind-core`'s
+listener protocol to network clients. Clients authenticate via a Base64
+query-parameter and exchange `HiveMessage` frames over the socket.
+
+## Key Classes
+
+| Class | Purpose | Source |
+|---|---|---|
+| `HiveMindWebsocketProtocol` | `NetworkProtocol` plugin; configures and starts the Tornado server | `hivemind_websocket_protocol/__init__.py:50` |
+| `HiveMindTornadoWebSocket` | Tornado `WebSocketHandler`; auth, message dispatch, IP resolution | `hivemind_websocket_protocol/__init__.py:161` |
+| `resolve_client_ip()` | Resolves real client IP from forwarded headers when peer is a trusted proxy | `hivemind_websocket_protocol/_client_ip.py:28` |
+| `parse_networks()` | Parses CIDR strings into `ipaddress` network objects | `hivemind_websocket_protocol/_client_ip.py:10` |
+
+## Contents
+
+- [Installation & Quick Start](../README.md)
+- [Architecture](architecture.md)
+- [Configuration Reference](configuration.md)
+- [Development](development.md)


### PR DESCRIPTION
Documentation-only PR — stacks on top of #15 (assumes merged into dev).

## What
- Replace the 4-line README stub with Install / Quick Start / Configuration sections covering both connection settings (`host`, `port`, `ssl`, `cert_dir`, `cert_name`) and the trusted-proxy env vars from #15.
- Add a small \`/docs/\` directory:
  - \`index.md\` — package overview, key classes table
  - \`architecture.md\` — transport, handler lifecycle, auth flow, IP resolution algorithm
  - \`configuration.md\` — full config dict + env var reference with examples
  - \`development.md\` — project layout, running tests, entry-point registration
- Source citations link prose to \`__init__.py\` / \`_client_ip.py\` line numbers.

## What this PR does not touch
- Code: no functional changes.
- CHANGELOG: handled by release automation.

## Note on ordering
If #15 has not yet been merged when this lands in review, the diff will contain #15's code as well. Once #15 merges, this PR rebases to a docs-only diff.