### PR TITLE
fix: drop removed message_blacklist read (+ sha256 cert)

### DIFF
--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -149,8 +149,7 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
             cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
             cert.set_issuer(cert.get_subject())
             cert.set_pubkey(k)
-            # TODO: Don't use SHA1
-            cert.sign(k, "sha1")
+            cert.sign(k, "sha256")
 
             open(cert_path, "wb").write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
             open(key_path, "wb").write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k))
@@ -253,7 +252,6 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
 
         self.client.name = f"{useragent}::{user.client_id}::{user.name}"
         self.client.crypto_key = user.crypto_key
-        self.client.msg_blacklist = user.message_blacklist or []
         self.client.skill_blacklist = user.skill_blacklist or []
         self.client.intent_blacklist = user.intent_blacklist or []
         self.client.allowed_types = user.allowed_types


### PR DESCRIPTION
Clean version of #27. `message_blacklist` was removed from the client model (hivemind-core is whitelist-only via `allowed_types`), so reading `user.message_blacklist` during auth is dead — drop it rather than defaulting it. Pairs with the no-op read shim in hivemind-plugin-manager#35 for any remaining external readers. Also ports the sha1→sha256 self-signed cert fix from #27.

Closes/supersedes #27 (fork branch).