### PR TITLE
Add websocket ping settings

### DIFF
--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import math
 import os
 import os.path
 import random
@@ -36,6 +37,8 @@ from hivemind_websocket_protocol._client_ip import (
 
 
 DEFAULT_TRUSTED_HEADERS = "x-forwarded-for,x-real-ip"
+DEFAULT_WEBSOCKET_PING_INTERVAL = 30.0
+DEFAULT_WEBSOCKET_PING_TIMEOUT = 20.0
 
 
 def _split_csv(value: Any) -> Tuple[str, ...]:
@@ -44,6 +47,23 @@ def _split_csv(value: Any) -> Tuple[str, ...]:
     if isinstance(value, str):
         return tuple(v.strip() for v in value.split(",") if v.strip())
     return tuple(str(v).strip() for v in value if str(v).strip())
+
+
+def _non_negative_float(value: Any, default: float, name: str) -> float:
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        LOG.warning(f"Ignoring invalid {name}: {value!r}")
+        return default
+    if not math.isfinite(parsed):
+        LOG.warning(f"Ignoring invalid {name}: {value!r}")
+        return default
+    if parsed < 0:
+        LOG.warning(f"Ignoring negative {name}: {value!r}")
+        return default
+    return parsed
 
 
 @dataclasses.dataclass
@@ -57,6 +77,28 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
     config: Dict[str, Any] = dataclasses.field(default_factory=dict)
     hm_protocol: Optional[HiveMindListenerProtocol] = None
     callbacks: ClientCallbacks = dataclasses.field(default_factory=ClientCallbacks)
+
+    def _websocket_ping_settings(self) -> Dict[str, float]:
+        interval = self.config.get(
+            "websocket_ping_interval",
+            os.getenv("HIVEMIND_WEBSOCKET_PING_INTERVAL"),
+        )
+        timeout = self.config.get(
+            "websocket_ping_timeout",
+            os.getenv("HIVEMIND_WEBSOCKET_PING_TIMEOUT"),
+        )
+        return {
+            "websocket_ping_interval": _non_negative_float(
+                interval,
+                DEFAULT_WEBSOCKET_PING_INTERVAL,
+                "websocket_ping_interval",
+            ),
+            "websocket_ping_timeout": _non_negative_float(
+                timeout,
+                DEFAULT_WEBSOCKET_PING_TIMEOUT,
+                "websocket_ping_timeout",
+            ),
+        }
 
     def run(self):
         LOG.debug(f"websocket server config: {self.config}")
@@ -87,16 +129,18 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
         port = int(self.config.get("port") or self.identity.default_port or 5678)
 
         routes: list = [("/", HiveMindTornadoWebSocket)]
+        websocket_ping_settings = self._websocket_ping_settings()
         application = web.Application(
             routes,
             trusted_networks=trusted_networks,
             trusted_headers=trusted_headers,
+            **websocket_ping_settings,
         )
         if ssl:
             cert_file = f"{cert_dir}/{cert_name}.crt"
             key_file = f"{cert_dir}/{cert_name}.key"
             if not os.path.isfile(key_file):
-                LOG.info(f"generating self-signed SSL certificate")
+                LOG.info("generating self-signed SSL certificate")
                 cert_file, key_file = self.create_self_signed_cert(cert_dir, cert_name)
             LOG.debug("using ssl key at " + key_file)
             LOG.debug("using ssl certificate at " + cert_file)

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -17,6 +17,8 @@ from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 import asyncio
 
 from hivemind_websocket_protocol import (
+    DEFAULT_WEBSOCKET_PING_INTERVAL,
+    DEFAULT_WEBSOCKET_PING_TIMEOUT,
     HiveMindTornadoWebSocket,
     HiveMindWebsocketProtocol,
 )
@@ -35,6 +37,66 @@ def test_version_module_exposes_constants_and_string():
     assert v.__version__.startswith(
         f"{v.VERSION_MAJOR}.{v.VERSION_MINOR}.{v.VERSION_BUILD}"
     )
+
+
+# --- websocket ping settings -----------------------------------------------
+
+def test_websocket_ping_settings_default(monkeypatch):
+    monkeypatch.delenv("HIVEMIND_WEBSOCKET_PING_INTERVAL", raising=False)
+    monkeypatch.delenv("HIVEMIND_WEBSOCKET_PING_TIMEOUT", raising=False)
+    proto = HiveMindWebsocketProtocol(config={})
+
+    assert proto._websocket_ping_settings() == {
+        "websocket_ping_interval": DEFAULT_WEBSOCKET_PING_INTERVAL,
+        "websocket_ping_timeout": DEFAULT_WEBSOCKET_PING_TIMEOUT,
+    }
+
+
+def test_websocket_ping_settings_from_env(monkeypatch):
+    monkeypatch.setenv("HIVEMIND_WEBSOCKET_PING_INTERVAL", "25")
+    monkeypatch.setenv("HIVEMIND_WEBSOCKET_PING_TIMEOUT", "15")
+    proto = HiveMindWebsocketProtocol(config={})
+
+    assert proto._websocket_ping_settings() == {
+        "websocket_ping_interval": 25.0,
+        "websocket_ping_timeout": 15.0,
+    }
+
+
+def test_websocket_ping_settings_config_wins_over_env(monkeypatch):
+    monkeypatch.setenv("HIVEMIND_WEBSOCKET_PING_INTERVAL", "25")
+    monkeypatch.setenv("HIVEMIND_WEBSOCKET_PING_TIMEOUT", "15")
+    proto = HiveMindWebsocketProtocol(
+        config={"websocket_ping_interval": 10, "websocket_ping_timeout": 5}
+    )
+
+    assert proto._websocket_ping_settings() == {
+        "websocket_ping_interval": 10.0,
+        "websocket_ping_timeout": 5.0,
+    }
+
+
+def test_websocket_ping_settings_invalid_values_fall_back(monkeypatch):
+    monkeypatch.setenv("HIVEMIND_WEBSOCKET_PING_INTERVAL", "-1")
+    monkeypatch.setenv("HIVEMIND_WEBSOCKET_PING_TIMEOUT", "nope")
+    proto = HiveMindWebsocketProtocol(config={})
+
+    assert proto._websocket_ping_settings() == {
+        "websocket_ping_interval": DEFAULT_WEBSOCKET_PING_INTERVAL,
+        "websocket_ping_timeout": DEFAULT_WEBSOCKET_PING_TIMEOUT,
+    }
+
+
+@pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+def test_websocket_ping_settings_non_finite_values_fall_back(monkeypatch, value):
+    monkeypatch.setenv("HIVEMIND_WEBSOCKET_PING_INTERVAL", value)
+    monkeypatch.setenv("HIVEMIND_WEBSOCKET_PING_TIMEOUT", value)
+    proto = HiveMindWebsocketProtocol(config={})
+
+    assert proto._websocket_ping_settings() == {
+        "websocket_ping_interval": DEFAULT_WEBSOCKET_PING_INTERVAL,
+        "websocket_ping_timeout": DEFAULT_WEBSOCKET_PING_TIMEOUT,
+    }
 
 
 # --- self-signed cert generation ------------------------------------------
@@ -201,5 +263,3 @@ def test_run_ssl_path_generates_missing_cert(tmp_path):
     assert not t.is_alive()
     assert (cert_dir / "gen-me.crt").exists()
     assert (cert_dir / "gen-me.key").exists()
-
-


### PR DESCRIPTION
I hit idle websocket disconnects when running HiveMind behind Cloudflare.

Tornado already supports websocket ping/pong, so this just wires the settings into the protocol app. Defaults are 30s ping interval and 20s timeout, with config/env overrides if someone needs different values.

Env vars:
- HIVEMIND_WEBSOCKET_PING_INTERVAL
- HIVEMIND_WEBSOCKET_PING_TIMEOUT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket connections now support configurable ping interval and timeout with sensible defaults (30s interval, 20s timeout). Settings can be provided via configuration or environment variables; invalid or missing values fall back to defaults.

* **Tests**
  * Added unit coverage for the new ping/timeout configuration behavior and various validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->