### PR TITLE
fix: pin poorman-handshake>=2.0.0a1 + disable-able runtime password backstop

### DIFF
--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -22,6 +22,7 @@ from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 from tornado.websocket import WebSocketHandler
 
 from hivemind_bus_client.message import HiveMessageType
+from hivemind_core.config import runtime_password_min_bits
 from hivemind_core.protocol import (
     HiveMindListenerProtocol,
     HiveMindClientConnection,
@@ -305,7 +306,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         self.client.is_admin = user.is_admin
         if user.password:
             # pre-shared password to derive aes_key
-            self.client.pswd_handshake = PasswordHandShake(user.password)
+            self.client.pswd_handshake = PasswordHandShake(user.password, min_bits=runtime_password_min_bits())
 
         self.client.node_type = HiveMindNodeType.NODE  # TODO . placeholder
 

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -22,7 +22,14 @@ from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 from tornado.websocket import WebSocketHandler
 
 from hivemind_bus_client.message import HiveMessageType
-from hivemind_core.config import runtime_password_min_bits
+try:
+    from hivemind_core.config import runtime_password_min_bits
+except ImportError:  # released hivemind-core without the helper
+    import os
+
+    def runtime_password_min_bits():
+        return 0.0 if os.environ.get("HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK", "").strip().lower() in ("1", "true", "yes", "on") else 40.0
+
 from hivemind_core.protocol import (
     HiveMindListenerProtocol,
     HiveMindClientConnection,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ requires-python = ">=3.10"
 dependencies = [
     "tornado",
     "hivemind-plugin-manager",
-    "poorman_handshake>=0.1.0",
+    "poorman-handshake>=2.0.0a1,<3.0.0",
+    "hivemind-core",
     "pyOpenSSL",
     "pybase64",
 ]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -75,7 +75,7 @@ def _spawn_tornado(trusted_networks=(), trusted_headers=()):
     teardown via `_teardown_tornado(thread, loop)`.
     """
     api_key = "test-api-key"
-    password = "test-password"
+    password = "correct-horse-battery-staple-9$"
 
     master = MasterNode.create("M0", require_crypto=False, handshake_enabled=True)
     master.register_satellite(

--- a/tests/e2e/test_tornado_transport.py
+++ b/tests/e2e/test_tornado_transport.py
@@ -17,9 +17,9 @@ from hivemind_bus_client import HiveMessageBusClient
 
 # --- helpers --------------------------------------------------------------
 
-def _client(server, *, useragent="e2e", password=None):
+def _client(server, *, useragent="e2e", password=None, key=None):
     c = HiveMessageBusClient(
-        key=server.api_key,
+        key=key or server.api_key,
         password=password if password is not None else server.password,
         host=server.host,
         port=server.port,
@@ -70,8 +70,21 @@ def test_disconnect_releases_client_on_listener(tornado_server):
 
 
 def test_multiple_concurrent_clients(tornado_server):
+    # each client needs its own api key: protocol v3 pins the Noise static
+    # pubkey of the first connection for a given key, so a second client
+    # sharing the same key would be rejected as an impostor
+    second_key = "test-api-key-b"
+    tornado_server.master.register_satellite(
+        second_key,
+        password=tornado_server.password,
+        allowed_types=[
+            "recognizer_loop:utterance",
+            "recognizer_loop:b64_audio",
+            "speak",
+        ],
+    )
     a = _client(tornado_server, useragent="ua-a")
-    b = _client(tornado_server, useragent="ua-b")
+    b = _client(tornado_server, useragent="ua-b", key=second_key)
     try:
         _wait_clients(tornado_server, 2)
         assert len(tornado_server.listener.clients) == 2
@@ -92,9 +105,10 @@ def test_bad_api_key_is_rejected(tornado_server):
         useragent="bad-key",
         self_signed=False,
     )
-    # connect() raises if handshake times out; catch that.
+    # bound the handshake retries so a rejected key fails fast instead of
+    # reconnecting forever
     with pytest.raises(RuntimeError):
-        bad.connect()
+        bad.connect(handshake_max_retries=2)
     bad.close()
     _wait(lambda: not tornado_server.listener.clients, timeout=2)
     assert not tornado_server.listener.clients


### PR DESCRIPTION
## Summary

- Pins `poorman-handshake>=2.0.0a1,<3.0.0` (2.x encryption/handshake API).
- Wires the poorman 2.0 password-strength check as a **runtime security backstop**: `PasswordHandShake(user.password, min_bits=runtime_password_min_bits())`. This catches weak passwords inserted by editing the database directly, at handshake time.
- The backstop is disable-able: set env `HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK=1` or config `runtime_password_strength_check: false` (helper `runtime_password_min_bits()` in `hivemind_core.config` returns 0 when disabled, else configured `min_password_bits`, default 40).
- Adds `hivemind-core` to runtime deps (module already imported `hivemind_core.protocol`; the dep was implicit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)