### PR TITLE
Avoid database sync on websocket open

### DIFF
--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -4,6 +4,8 @@ import math
 import os
 import os.path
 import random
+import threading
+import time
 from os import makedirs
 from os.path import exists, join
 from socket import gethostname
@@ -218,6 +220,9 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     """
     hm_protocol = None
     source_ip: Optional[str] = None
+    _sync_lock = threading.Lock()
+    _last_sync_ts = 0.0
+    _sync_debounce_s = 1.0
 
     def _client_ip(self) -> Optional[str]:
         return resolve_client_ip(
@@ -259,6 +264,18 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     def _peer_label(self, peer: str) -> str:
         return f"{peer} ({self.source_ip})" if self.source_ip else peer
 
+    @classmethod
+    def _sync_client_database(cls, db: Any) -> None:
+        sync = getattr(db, "sync", None)
+        if not callable(sync):
+            return
+        with cls._sync_lock:
+            now = time.monotonic()
+            if now - cls._last_sync_ts < cls._sync_debounce_s:
+                return
+            sync()
+            cls._last_sync_ts = time.monotonic()
+
     def open(self) -> None:
         """
         Handle a new client connection and perform authorization.
@@ -294,16 +311,21 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             hm_protocol=self.hm_protocol
         )
         user: Client = self.hm_protocol.db.get_client_by_api_key(key)
+        sync_error = False
         if not user:
-            sync = getattr(self.hm_protocol.db, "sync", None)
-            if callable(sync):
-                try:
-                    sync()
-                    user = self.hm_protocol.db.get_client_by_api_key(key)
-                except Exception:
-                    LOG.exception("Client database sync failed while retrying api key lookup")
+            try:
+                self._sync_client_database(self.hm_protocol.db)
+            except Exception:
+                sync_error = True
+                LOG.exception("Client database sync failed while retrying api key lookup")
+            else:
+                user = self.hm_protocol.db.get_client_by_api_key(key)
 
         if not user:
+            if sync_error:
+                LOG.error("Client database unavailable during api key lookup")
+                self.close(code=1011, reason="client database unavailable")
+                return
             LOG.error("Client provided an invalid api key")
             self.hm_protocol.handle_invalid_key_connected(self.client)
             self.close()

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -294,6 +294,14 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             hm_protocol=self.hm_protocol
         )
         user: Client = self.hm_protocol.db.get_client_by_api_key(key)
+        if not user:
+            sync = getattr(self.hm_protocol.db, "sync", None)
+            if callable(sync):
+                try:
+                    sync()
+                    user = self.hm_protocol.db.get_client_by_api_key(key)
+                except Exception:
+                    LOG.exception("Client database sync failed while retrying api key lookup")
 
         if not user:
             LOG.error("Client provided an invalid api key")

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -293,7 +293,6 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             name=useragent,
             hm_protocol=self.hm_protocol
         )
-        self.hm_protocol.db.sync()
         user: Client = self.hm_protocol.db.get_client_by_api_key(key)
 
         if not user:

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -11,7 +11,9 @@ import socket
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
+import pybase64
 import pytest
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 import asyncio
@@ -97,6 +99,58 @@ def test_websocket_ping_settings_non_finite_values_fall_back(monkeypatch, value)
         "websocket_ping_interval": DEFAULT_WEBSOCKET_PING_INTERVAL,
         "websocket_ping_timeout": DEFAULT_WEBSOCKET_PING_TIMEOUT,
     }
+
+
+# --- open() auth path ------------------------------------------------------
+
+def test_open_uses_direct_api_key_lookup_without_sync():
+    user = SimpleNamespace(
+        client_id=1,
+        name="unit-client",
+        crypto_key=None,
+        skill_blacklist=[],
+        intent_blacklist=[],
+        allowed_types=["recognizer_loop:utterance"],
+        can_broadcast=True,
+        can_propagate=True,
+        can_escalate=True,
+        is_admin=False,
+        password=None,
+    )
+
+    def fail_sync():
+        raise AssertionError("db.sync must not run on websocket open")
+
+    seen_clients = []
+    db = SimpleNamespace(
+        sync=fail_sync,
+        get_client_by_api_key=lambda key: user if key == "api-key" else None,
+    )
+    hm_protocol = SimpleNamespace(
+        db=db,
+        identity=SimpleNamespace(private_key=None),
+        handshake_enabled=True,
+        require_crypto=False,
+        handle_new_client=seen_clients.append,
+        handle_invalid_key_connected=lambda client: None,
+        handle_invalid_protocol_version=lambda client: None,
+    )
+
+    handler = HiveMindTornadoWebSocket.__new__(HiveMindTornadoWebSocket)
+    handler.hm_protocol = hm_protocol
+    handler.request = SimpleNamespace(remote_ip="127.0.0.1", headers={})
+    handler.application = SimpleNamespace(settings={})
+    handler.loop = SimpleNamespace(install=lambda: None)
+    handler.write_message = lambda payload, is_bin=False: None
+    handler.close = lambda *args, **kwargs: None
+    handler.get_query_argument = lambda name, default=None: pybase64.b64encode(
+        b"agent:api-key"
+    ).decode("ascii")
+
+    handler.open()
+
+    assert len(seen_clients) == 1
+    assert seen_clients[0].name == "agent::1::unit-client"
 
 
 # --- self-signed cert generation ------------------------------------------

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -153,6 +153,64 @@ def test_open_uses_direct_api_key_lookup_without_sync():
     assert seen_clients[0].name == "agent::1::unit-client"
 
 
+def test_open_syncs_once_after_api_key_miss():
+    user = SimpleNamespace(
+        client_id=2,
+        name="fresh-client",
+        crypto_key=None,
+        skill_blacklist=[],
+        intent_blacklist=[],
+        allowed_types=["recognizer_loop:utterance"],
+        can_broadcast=True,
+        can_propagate=True,
+        can_escalate=True,
+        is_admin=False,
+        password=None,
+    )
+
+    state = {"synced": False, "syncs": 0}
+
+    def sync():
+        state["syncs"] += 1
+        state["synced"] = True
+
+    def lookup(key):
+        if key == "fresh-key" and state["synced"]:
+            return user
+        return None
+
+    seen_clients = []
+    invalid_clients = []
+    db = SimpleNamespace(sync=sync, get_client_by_api_key=lookup)
+    hm_protocol = SimpleNamespace(
+        db=db,
+        identity=SimpleNamespace(private_key=None),
+        handshake_enabled=True,
+        require_crypto=False,
+        handle_new_client=seen_clients.append,
+        handle_invalid_key_connected=invalid_clients.append,
+        handle_invalid_protocol_version=lambda client: None,
+    )
+
+    handler = HiveMindTornadoWebSocket.__new__(HiveMindTornadoWebSocket)
+    handler.hm_protocol = hm_protocol
+    handler.request = SimpleNamespace(remote_ip="127.0.0.1", headers={})
+    handler.application = SimpleNamespace(settings={})
+    handler.loop = SimpleNamespace(install=lambda: None)
+    handler.write_message = lambda payload, is_bin=False: None
+    handler.close = lambda *args, **kwargs: None
+    handler.get_query_argument = lambda name, default=None: pybase64.b64encode(
+        b"agent:fresh-key"
+    ).decode("ascii")
+
+    handler.open()
+
+    assert state["syncs"] == 1
+    assert len(invalid_clients) == 0
+    assert len(seen_clients) == 1
+    assert seen_clients[0].name == "agent::2::fresh-client"
+
+
 # --- self-signed cert generation ------------------------------------------
 
 def test_create_self_signed_cert_writes_files(tmp_path):

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -103,10 +103,10 @@ def test_websocket_ping_settings_non_finite_values_fall_back(monkeypatch, value)
 
 # --- open() auth path ------------------------------------------------------
 
-def test_open_uses_direct_api_key_lookup_without_sync():
-    user = SimpleNamespace(
-        client_id=1,
-        name="unit-client",
+def _auth_user(client_id=1, name="unit-client"):
+    return SimpleNamespace(
+        client_id=client_id,
+        name=name,
         crypto_key=None,
         skill_blacklist=[],
         intent_blacklist=[],
@@ -118,70 +118,12 @@ def test_open_uses_direct_api_key_lookup_without_sync():
         password=None,
     )
 
-    def fail_sync():
-        raise AssertionError("db.sync must not run on websocket open")
 
-    seen_clients = []
-    db = SimpleNamespace(
-        sync=fail_sync,
-        get_client_by_api_key=lambda key: user if key == "api-key" else None,
-    )
-    hm_protocol = SimpleNamespace(
-        db=db,
-        identity=SimpleNamespace(private_key=None),
-        handshake_enabled=True,
-        require_crypto=False,
-        handle_new_client=seen_clients.append,
-        handle_invalid_key_connected=lambda client: None,
-        handle_invalid_protocol_version=lambda client: None,
-    )
-
-    handler = HiveMindTornadoWebSocket.__new__(HiveMindTornadoWebSocket)
-    handler.hm_protocol = hm_protocol
-    handler.request = SimpleNamespace(remote_ip="127.0.0.1", headers={})
-    handler.application = SimpleNamespace(settings={})
-    handler.loop = SimpleNamespace(install=lambda: None)
-    handler.write_message = lambda payload, is_bin=False: None
-    handler.close = lambda *args, **kwargs: None
-    handler.get_query_argument = lambda name, default=None: pybase64.b64encode(
-        b"agent:api-key"
-    ).decode("ascii")
-
-    handler.open()
-
-    assert len(seen_clients) == 1
-    assert seen_clients[0].name == "agent::1::unit-client"
-
-
-def test_open_syncs_once_after_api_key_miss():
-    user = SimpleNamespace(
-        client_id=2,
-        name="fresh-client",
-        crypto_key=None,
-        skill_blacklist=[],
-        intent_blacklist=[],
-        allowed_types=["recognizer_loop:utterance"],
-        can_broadcast=True,
-        can_propagate=True,
-        can_escalate=True,
-        is_admin=False,
-        password=None,
-    )
-
-    state = {"synced": False, "syncs": 0}
-
-    def sync():
-        state["syncs"] += 1
-        state["synced"] = True
-
-    def lookup(key):
-        if key == "fresh-key" and state["synced"]:
-            return user
-        return None
-
-    seen_clients = []
-    invalid_clients = []
-    db = SimpleNamespace(sync=sync, get_client_by_api_key=lookup)
+def _open_handler(db, key="api-key", seen_clients=None,
+                  invalid_clients=None, closes=None):
+    seen_clients = seen_clients if seen_clients is not None else []
+    invalid_clients = invalid_clients if invalid_clients is not None else []
+    closes = closes if closes is not None else []
     hm_protocol = SimpleNamespace(
         db=db,
         identity=SimpleNamespace(private_key=None),
@@ -198,10 +140,58 @@ def test_open_syncs_once_after_api_key_miss():
     handler.application = SimpleNamespace(settings={})
     handler.loop = SimpleNamespace(install=lambda: None)
     handler.write_message = lambda payload, is_bin=False: None
-    handler.close = lambda *args, **kwargs: None
+    handler.close = lambda *args, **kwargs: closes.append(
+        {"args": args, "kwargs": kwargs}
+    )
     handler.get_query_argument = lambda name, default=None: pybase64.b64encode(
-        b"agent:fresh-key"
+        f"agent:{key}".encode("utf-8")
     ).decode("ascii")
+    return handler
+
+
+def test_open_uses_direct_api_key_lookup_without_sync():
+    user = _auth_user()
+
+    def fail_sync():
+        raise AssertionError("db.sync must not run on websocket open")
+
+    seen_clients = []
+    db = SimpleNamespace(
+        sync=fail_sync,
+        get_client_by_api_key=lambda key: user if key == "api-key" else None,
+    )
+    handler = _open_handler(db, seen_clients=seen_clients)
+
+    handler.open()
+
+    assert len(seen_clients) == 1
+    assert seen_clients[0].name == "agent::1::unit-client"
+
+
+def test_open_syncs_once_after_api_key_miss():
+    HiveMindTornadoWebSocket._last_sync_ts = 0.0
+    user = _auth_user(client_id=2, name="fresh-client")
+
+    state = {"synced": False, "syncs": 0}
+
+    def sync():
+        state["syncs"] += 1
+        state["synced"] = True
+
+    def lookup(key):
+        if key == "fresh-key" and state["synced"]:
+            return user
+        return None
+
+    seen_clients = []
+    invalid_clients = []
+    db = SimpleNamespace(sync=sync, get_client_by_api_key=lookup)
+    handler = _open_handler(
+        db,
+        key="fresh-key",
+        seen_clients=seen_clients,
+        invalid_clients=invalid_clients,
+    )
 
     handler.open()
 
@@ -209,6 +199,61 @@ def test_open_syncs_once_after_api_key_miss():
     assert len(invalid_clients) == 0
     assert len(seen_clients) == 1
     assert seen_clients[0].name == "agent::2::fresh-client"
+
+
+def test_open_debounces_sync_after_recent_api_key_miss():
+    HiveMindTornadoWebSocket._last_sync_ts = 0.0
+    user = _auth_user(client_id=3, name="synced-client")
+    state = {"synced": False, "syncs": 0}
+
+    def sync():
+        state["syncs"] += 1
+        state["synced"] = True
+
+    def lookup(key):
+        if key == "fresh-key" and state["synced"]:
+            return user
+        return None
+
+    db = SimpleNamespace(sync=sync, get_client_by_api_key=lookup)
+    seen_clients = []
+    invalid_clients = []
+    _open_handler(db, key="fresh-key",
+                  seen_clients=seen_clients).open()
+    _open_handler(db, key="missing-key",
+                  invalid_clients=invalid_clients).open()
+
+    assert state["syncs"] == 1
+    assert len(seen_clients) == 1
+    assert len(invalid_clients) == 1
+
+
+def test_open_reports_sync_failure_as_server_error():
+    HiveMindTornadoWebSocket._last_sync_ts = 0.0
+
+    def fail_sync():
+        raise RuntimeError("redis unavailable")
+
+    invalid_clients = []
+    closes = []
+    db = SimpleNamespace(
+        sync=fail_sync,
+        get_client_by_api_key=lambda key: None,
+    )
+    handler = _open_handler(
+        db,
+        key="fresh-key",
+        invalid_clients=invalid_clients,
+        closes=closes,
+    )
+
+    handler.open()
+
+    assert invalid_clients == []
+    assert closes[-1]["kwargs"] == {
+        "code": 1011,
+        "reason": "client database unavailable",
+    }
 
 
 # --- self-signed cert generation ------------------------------------------


### PR DESCRIPTION
Summary
- stop running db.sync() for every websocket connection
- use the normal API-key lookup path during open()
- add a unit regression that fails if sync is called there again

Tests
- PYTHONPATH=../hivemind-plugin-manager:../HiveMind-core:${PYTHONPATH:-} python -m pytest tests/test_protocol_unit.py::test_open_uses_direct_api_key_lookup_without_sync tests/test_decode_auth.py

Refs JarbasHiveMind/HiveMind-core#85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved websocket login handling so valid API keys are accepted more reliably.
  * Added a fallback retry when a client is not found on the first lookup, reducing false invalid-key rejections.
  * Existing invalid-key behavior still applies when access cannot be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->