### PR TITLE
Bind websocket listener on its own loop

### DIFF
--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -18,7 +18,6 @@ from ovos_utils.xdg_utils import xdg_data_home
 from poorman_handshake import PasswordHandShake
 from tornado import ioloop
 from tornado import web
-from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 from tornado.websocket import WebSocketHandler
 
 from hivemind_bus_client.message import HiveMessageType
@@ -110,8 +109,10 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
 
     def run(self):
         LOG.debug(f"websocket server config: {self.config}")
-        asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
-        HiveMindTornadoWebSocket.loop = ioloop.IOLoop.current()
+        asyncio_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(asyncio_loop)
+        loop = ioloop.IOLoop.current()
+        HiveMindTornadoWebSocket.loop = loop
         HiveMindTornadoWebSocket.hm_protocol = self.hm_protocol
 
         if "trusted_proxy_cidrs" in self.config:
@@ -144,23 +145,31 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
             trusted_headers=trusted_headers,
             **websocket_ping_settings,
         )
-        if ssl:
-            cert_file = f"{cert_dir}/{cert_name}.crt"
-            key_file = f"{cert_dir}/{cert_name}.key"
-            if not os.path.isfile(key_file):
-                LOG.info("generating self-signed SSL certificate")
-                cert_file, key_file = self.create_self_signed_cert(cert_dir, cert_name)
-            LOG.debug("using ssl key at " + key_file)
-            LOG.debug("using ssl certificate at " + cert_file)
-            ssl_options = {"certfile": cert_file, "keyfile": key_file}
 
-            LOG.info("wss listener started")
-            application.listen(port, host, ssl_options=ssl_options)
-        else:
-            LOG.info("ws listener started")
-            application.listen(port, host)
+        def start_listener() -> None:
+            try:
+                if ssl:
+                    cert_file = f"{cert_dir}/{cert_name}.crt"
+                    key_file = f"{cert_dir}/{cert_name}.key"
+                    if not os.path.isfile(key_file):
+                        LOG.info("generating self-signed SSL certificate")
+                        cert_file, key_file = self.create_self_signed_cert(
+                            cert_dir, cert_name
+                        )
+                    LOG.debug("using ssl key at " + key_file)
+                    LOG.debug("using ssl certificate at " + cert_file)
+                    ssl_options = {"certfile": cert_file, "keyfile": key_file}
+                    application.listen(port, host, ssl_options=ssl_options)
+                    LOG.info("wss listener started")
+                else:
+                    application.listen(port, host)
+                    LOG.info("ws listener started")
+            except Exception:
+                LOG.exception("failed to start websocket listener")
+                loop.stop()
 
-        HiveMindTornadoWebSocket.loop.start()  # blocking
+        loop.add_callback(start_listener)
+        loop.start()  # blocking
 
     @staticmethod
     def create_self_signed_cert(

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -145,8 +145,10 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
             trusted_headers=trusted_headers,
             **websocket_ping_settings,
         )
+        startup_error: Optional[Exception] = None
 
         def start_listener() -> None:
+            nonlocal startup_error
             try:
                 if ssl:
                     cert_file = f"{cert_dir}/{cert_name}.crt"
@@ -164,12 +166,15 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
                 else:
                     application.listen(port, host)
                     LOG.info("ws listener started")
-            except Exception:
+            except Exception as e:
+                startup_error = e
                 LOG.exception("failed to start websocket listener")
                 loop.stop()
 
         loop.add_callback(start_listener)
         loop.start()  # blocking
+        if startup_error is not None:
+            raise startup_error
 
     @staticmethod
     def create_self_signed_cert(

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -187,6 +187,27 @@ def test_run_starts_and_serves_on_plain_ws():
     assert not t.is_alive(), "run() did not return after ioloop.stop()"
 
 
+def test_run_raises_when_listener_bind_fails():
+    """Bind failures should propagate instead of looking like clean exits."""
+    master = MasterNode.create("MF", require_crypto=False, handshake_enabled=True)
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    blocker.bind(("127.0.0.1", 0))
+    blocker.listen(1)
+    port = blocker.getsockname()[1]
+    proto = HiveMindWebsocketProtocol(
+        config={"host": "127.0.0.1", "port": port, "ssl": False},
+        hm_protocol=master.hm_protocol,
+    )
+    if hasattr(HiveMindTornadoWebSocket, "loop"):
+        del HiveMindTornadoWebSocket.loop
+
+    try:
+        with pytest.raises(OSError):
+            proto.run()
+    finally:
+        blocker.close()
+
+
 def test_run_ssl_path_uses_existing_cert(tmp_path):
     """SSL branch in run(): existing cert is picked up; no regeneration."""
     cert, key = HiveMindWebsocketProtocol.create_self_signed_cert(


### PR DESCRIPTION
Fixes #34

Starts the Tornado listener from the loop it owns, and logs startup failures instead of leaving the websocket port silently dead.

Tested:
- python -m pytest tests/test_protocol_unit.py tests/e2e/test_tornado_transport.py tests/e2e/test_smoke.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket server startup reliability, with better handling of startup failures and cleaner shutdown behavior.
  * Enhanced SSL-enabled startup to more consistently load or generate certificates before the server begins listening.

* **Refactor**
  * Restructured server startup flow for more predictable event loop setup and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->