### PR TITLE
Keep Tornado websocket sends on the IOLoop

### DIFF
--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -147,8 +147,10 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
             trusted_headers=trusted_headers,
             **websocket_ping_settings,
         )
+        startup_error: Optional[Exception] = None
 
         def start_listener() -> None:
+            nonlocal startup_error
             try:
                 if ssl:
                     cert_file = f"{cert_dir}/{cert_name}.crt"
@@ -166,12 +168,15 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
                 else:
                     application.listen(port, host)
                     LOG.info("ws listener started")
-            except Exception:
+            except Exception as e:
+                startup_error = e
                 LOG.exception("failed to start websocket listener")
                 loop.stop()
 
         loop.add_callback(start_listener)
         loop.start()  # blocking
+        if startup_error is not None:
+            raise startup_error
 
     @staticmethod
     def create_self_signed_cert(

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -18,7 +18,6 @@ from ovos_utils.xdg_utils import xdg_data_home
 from poorman_handshake import PasswordHandShake
 from tornado import ioloop
 from tornado import web
-from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 from tornado.websocket import WebSocketHandler
 
 from hivemind_bus_client.message import HiveMessageType
@@ -110,8 +109,10 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
 
     def run(self):
         LOG.debug(f"websocket server config: {self.config}")
-        asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
-        HiveMindTornadoWebSocket.loop = ioloop.IOLoop.current()
+        asyncio_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(asyncio_loop)
+        loop = ioloop.IOLoop.current()
+        HiveMindTornadoWebSocket.loop = loop
         HiveMindTornadoWebSocket.hm_protocol = self.hm_protocol
 
         if "trusted_proxy_cidrs" in self.config:
@@ -144,23 +145,31 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
             trusted_headers=trusted_headers,
             **websocket_ping_settings,
         )
-        if ssl:
-            cert_file = f"{cert_dir}/{cert_name}.crt"
-            key_file = f"{cert_dir}/{cert_name}.key"
-            if not os.path.isfile(key_file):
-                LOG.info("generating self-signed SSL certificate")
-                cert_file, key_file = self.create_self_signed_cert(cert_dir, cert_name)
-            LOG.debug("using ssl key at " + key_file)
-            LOG.debug("using ssl certificate at " + cert_file)
-            ssl_options = {"certfile": cert_file, "keyfile": key_file}
 
-            LOG.info("wss listener started")
-            application.listen(port, host, ssl_options=ssl_options)
-        else:
-            LOG.info("ws listener started")
-            application.listen(port, host)
+        def start_listener() -> None:
+            try:
+                if ssl:
+                    cert_file = f"{cert_dir}/{cert_name}.crt"
+                    key_file = f"{cert_dir}/{cert_name}.key"
+                    if not os.path.isfile(key_file):
+                        LOG.info("generating self-signed SSL certificate")
+                        cert_file, key_file = self.create_self_signed_cert(
+                            cert_dir, cert_name
+                        )
+                    LOG.debug("using ssl key at " + key_file)
+                    LOG.debug("using ssl certificate at " + cert_file)
+                    ssl_options = {"certfile": cert_file, "keyfile": key_file}
+                    application.listen(port, host, ssl_options=ssl_options)
+                    LOG.info("wss listener started")
+                else:
+                    application.listen(port, host)
+                    LOG.info("ws listener started")
+            except Exception:
+                LOG.exception("failed to start websocket listener")
+                loop.stop()
 
-        HiveMindTornadoWebSocket.loop.start()  # blocking
+        loop.add_callback(start_listener)
+        loop.start()  # blocking
 
     @staticmethod
     def create_self_signed_cert(

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -270,9 +270,9 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
                 message.msg_type == HiveMessageType.BUS
                 and message.payload.msg_type == "recognizer_loop:b64_audio"
         ):
-            LOG.info(f"Received {peer} sent base64 audio for STT")
+            LOG.debug(f"Received {peer} sent base64 audio for STT")
         else:
-            LOG.info(f"Received {peer} message: {message}")
+            LOG.debug(f"Received {peer} message: {message}")
         self.hm_protocol.handle_message(message, self.client)
 
     def _peer_label(self, peer: str) -> str:
@@ -306,7 +306,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             )
             self.close(code=1008, reason="invalid authorization")
             return
-        LOG.info(f"Authorizing client from {self.source_ip or 'unknown'} - {useragent}:{key}")
+        LOG.debug(f"Authorizing client from {self.source_ip or 'unknown'} - {useragent}")
 
         def do_send(payload: str, is_bin: bool):
             def _write():
@@ -394,7 +394,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
                 f"(no client was ever attached)"
             )
             return
-        LOG.info(f"disconnecting client: {self._peer_label(client.peer)}")
+        LOG.debug(f"disconnecting client: {self._peer_label(client.peer)}")
         self.hm_protocol.handle_client_disconnected(client)
 
     def check_origin(self, origin) -> bool:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -6,10 +6,12 @@ import os.path
 import random
 import threading
 import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
 from os import makedirs
 from os.path import exists, join
 from socket import gethostname
-from typing import Dict, Any, Optional, Tuple
+from typing import Deque, Dict, Any, Optional, Tuple
 
 import pybase64
 from OpenSSL import crypto
@@ -48,6 +50,8 @@ from hivemind_websocket_protocol._client_ip import (
 DEFAULT_TRUSTED_HEADERS = "x-forwarded-for,x-real-ip"
 DEFAULT_WEBSOCKET_PING_INTERVAL = 30.0
 DEFAULT_WEBSOCKET_PING_TIMEOUT = 20.0
+DEFAULT_WEBSOCKET_MESSAGE_WORKERS = 8
+DEFAULT_WEBSOCKET_MESSAGE_QUEUE = 64
 
 
 def _split_csv(value: Any) -> Tuple[str, ...]:
@@ -71,6 +75,20 @@ def _non_negative_float(value: Any, default: float, name: str) -> float:
         return default
     if parsed < 0:
         LOG.warning(f"Ignoring negative {name}: {value!r}")
+        return default
+    return parsed
+
+
+def _positive_int(value: Any, default: int, name: str) -> int:
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        LOG.warning(f"Ignoring invalid {name}: {value!r}")
+        return default
+    if parsed <= 0:
+        LOG.warning(f"Ignoring non-positive {name}: {value!r}")
         return default
     return parsed
 
@@ -116,6 +134,7 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
         loop = ioloop.IOLoop.current()
         HiveMindTornadoWebSocket.loop = loop
         HiveMindTornadoWebSocket.hm_protocol = self.hm_protocol
+        HiveMindTornadoWebSocket.configure_message_workers(self.config)
 
         if "trusted_proxy_cidrs" in self.config:
             proxy_cidrs = self.config["trusted_proxy_cidrs"]
@@ -234,9 +253,55 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     """
     hm_protocol = None
     source_ip: Optional[str] = None
+    _message_executor: Optional[ThreadPoolExecutor] = None
+    _message_workers = DEFAULT_WEBSOCKET_MESSAGE_WORKERS
+    _message_queue_size = DEFAULT_WEBSOCKET_MESSAGE_QUEUE
+    _message_executor_lock = threading.Lock()
     _sync_lock = threading.Lock()
     _last_sync_ts = 0.0
+    _last_sync_error: Optional[Exception] = None
     _sync_debounce_s = 1.0
+
+    def initialize(self) -> None:
+        self._inbound_messages: Deque[Any] = deque()
+        self._inbound_lock = threading.Lock()
+        self._inbound_draining = False
+
+    @classmethod
+    def configure_message_workers(cls, config: Dict[str, Any]) -> None:
+        workers = _positive_int(
+            config.get("websocket_message_workers")
+            or os.getenv("HIVEMIND_WEBSOCKET_MESSAGE_WORKERS"),
+            DEFAULT_WEBSOCKET_MESSAGE_WORKERS,
+            "websocket_message_workers",
+        )
+        queue_size = _positive_int(
+            config.get("websocket_message_queue")
+            or os.getenv("HIVEMIND_WEBSOCKET_MESSAGE_QUEUE"),
+            DEFAULT_WEBSOCKET_MESSAGE_QUEUE,
+            "websocket_message_queue",
+        )
+        with cls._message_executor_lock:
+            cls._message_queue_size = queue_size
+            if cls._message_executor is None or cls._message_workers != workers:
+                old_executor = cls._message_executor
+                cls._message_workers = workers
+                cls._message_executor = ThreadPoolExecutor(
+                    max_workers=workers,
+                    thread_name_prefix="hivemind-ws-message",
+                )
+                if old_executor is not None:
+                    old_executor.shutdown(wait=False, cancel_futures=True)
+
+    @classmethod
+    def _executor(cls) -> ThreadPoolExecutor:
+        with cls._message_executor_lock:
+            if cls._message_executor is None:
+                cls._message_executor = ThreadPoolExecutor(
+                    max_workers=cls._message_workers,
+                    thread_name_prefix="hivemind-ws-message",
+                )
+            return cls._message_executor
 
     def _client_ip(self) -> Optional[str]:
         return resolve_client_ip(
@@ -264,6 +329,39 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         return name, key
 
     def on_message(self, message: str) -> None:
+        with self._inbound_lock:
+            if len(self._inbound_messages) >= self._message_queue_size:
+                LOG.warning(
+                    "closing websocket from "
+                    f"{self._current_peer_label()}: "
+                    "inbound message queue is full"
+                )
+                self.close(code=1013, reason="message queue full")
+                return
+            self._inbound_messages.append(message)
+            if self._inbound_draining:
+                return
+            self._inbound_draining = True
+        self._executor().submit(self._drain_inbound_messages)
+
+    def _drain_inbound_messages(self) -> None:
+        while True:
+            with self._inbound_lock:
+                if not self._inbound_messages:
+                    self._inbound_draining = False
+                    return
+                message = self._inbound_messages.popleft()
+            try:
+                self._handle_inbound_message(message)
+            except Exception:
+                LOG.exception(
+                    "failed to process websocket message from "
+                    f"{self._current_peer_label()}"
+                )
+                self.loop.add_callback(self.close)
+                return
+
+    def _handle_inbound_message(self, message: str) -> None:
         message = self.client.decode(message)
         peer = self._peer_label(self.client.peer)
         if (
@@ -278,6 +376,10 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     def _peer_label(self, peer: str) -> str:
         return f"{peer} ({self.source_ip})" if self.source_ip else peer
 
+    def _current_peer_label(self) -> str:
+        client = getattr(self, "client", None)
+        return self._peer_label(getattr(client, "peer", "unknown"))
+
     @classmethod
     def _sync_client_database(cls, db: Any) -> None:
         sync = getattr(db, "sync", None)
@@ -286,9 +388,17 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         with cls._sync_lock:
             now = time.monotonic()
             if now - cls._last_sync_ts < cls._sync_debounce_s:
+                if cls._last_sync_error is not None:
+                    raise cls._last_sync_error
                 return
             cls._last_sync_ts = now
-            sync()
+            try:
+                sync()
+            except Exception as exc:
+                cls._last_sync_error = exc
+                raise
+            else:
+                cls._last_sync_error = None
 
     def open(self) -> None:
         """

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -4,6 +4,8 @@ import math
 import os
 import os.path
 import random
+import threading
+import time
 from os import makedirs
 from os.path import exists, join
 from socket import gethostname
@@ -227,6 +229,9 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     """
     hm_protocol = None
     source_ip: Optional[str] = None
+    _sync_lock = threading.Lock()
+    _last_sync_ts = 0.0
+    _sync_debounce_s = 1.0
 
     def _client_ip(self) -> Optional[str]:
         return resolve_client_ip(
@@ -268,6 +273,18 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     def _peer_label(self, peer: str) -> str:
         return f"{peer} ({self.source_ip})" if self.source_ip else peer
 
+    @classmethod
+    def _sync_client_database(cls, db: Any) -> None:
+        sync = getattr(db, "sync", None)
+        if not callable(sync):
+            return
+        with cls._sync_lock:
+            now = time.monotonic()
+            if now - cls._last_sync_ts < cls._sync_debounce_s:
+                return
+            sync()
+            cls._last_sync_ts = time.monotonic()
+
     def open(self) -> None:
         """
         Handle a new client connection and perform authorization.
@@ -303,16 +320,21 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             hm_protocol=self.hm_protocol
         )
         user: Client = self.hm_protocol.db.get_client_by_api_key(key)
+        sync_error = False
         if not user:
-            sync = getattr(self.hm_protocol.db, "sync", None)
-            if callable(sync):
-                try:
-                    sync()
-                    user = self.hm_protocol.db.get_client_by_api_key(key)
-                except Exception:
-                    LOG.exception("Client database sync failed while retrying api key lookup")
+            try:
+                self._sync_client_database(self.hm_protocol.db)
+            except Exception:
+                sync_error = True
+                LOG.exception("Client database sync failed while retrying api key lookup")
+            else:
+                user = self.hm_protocol.db.get_client_by_api_key(key)
 
         if not user:
+            if sync_error:
+                LOG.error("Client database unavailable during api key lookup")
+                self.close(code=1011, reason="client database unavailable")
+                return
             LOG.error("Client provided an invalid api key")
             self.hm_protocol.handle_invalid_key_connected(self.client)
             self.close()

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -287,8 +287,8 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             now = time.monotonic()
             if now - cls._last_sync_ts < cls._sync_debounce_s:
                 return
+            cls._last_sync_ts = now
             sync()
-            cls._last_sync_ts = time.monotonic()
 
     def open(self) -> None:
         """

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -6,12 +6,10 @@ import os.path
 import random
 import threading
 import time
-from collections import deque
-from concurrent.futures import ThreadPoolExecutor
 from os import makedirs
 from os.path import exists, join
 from socket import gethostname
-from typing import Deque, Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional, Tuple
 
 import pybase64
 from OpenSSL import crypto
@@ -50,8 +48,6 @@ from hivemind_websocket_protocol._client_ip import (
 DEFAULT_TRUSTED_HEADERS = "x-forwarded-for,x-real-ip"
 DEFAULT_WEBSOCKET_PING_INTERVAL = 30.0
 DEFAULT_WEBSOCKET_PING_TIMEOUT = 20.0
-DEFAULT_WEBSOCKET_MESSAGE_WORKERS = 8
-DEFAULT_WEBSOCKET_MESSAGE_QUEUE = 64
 
 
 def _split_csv(value: Any) -> Tuple[str, ...]:
@@ -75,20 +71,6 @@ def _non_negative_float(value: Any, default: float, name: str) -> float:
         return default
     if parsed < 0:
         LOG.warning(f"Ignoring negative {name}: {value!r}")
-        return default
-    return parsed
-
-
-def _positive_int(value: Any, default: int, name: str) -> int:
-    if value is None:
-        return default
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        LOG.warning(f"Ignoring invalid {name}: {value!r}")
-        return default
-    if parsed <= 0:
-        LOG.warning(f"Ignoring non-positive {name}: {value!r}")
         return default
     return parsed
 
@@ -134,7 +116,6 @@ class HiveMindWebsocketProtocol(NetworkProtocol):
         loop = ioloop.IOLoop.current()
         HiveMindTornadoWebSocket.loop = loop
         HiveMindTornadoWebSocket.hm_protocol = self.hm_protocol
-        HiveMindTornadoWebSocket.configure_message_workers(self.config)
 
         if "trusted_proxy_cidrs" in self.config:
             proxy_cidrs = self.config["trusted_proxy_cidrs"]
@@ -253,55 +234,10 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
     """
     hm_protocol = None
     source_ip: Optional[str] = None
-    _message_executor: Optional[ThreadPoolExecutor] = None
-    _message_workers = DEFAULT_WEBSOCKET_MESSAGE_WORKERS
-    _message_queue_size = DEFAULT_WEBSOCKET_MESSAGE_QUEUE
-    _message_executor_lock = threading.Lock()
     _sync_lock = threading.Lock()
     _last_sync_ts = 0.0
     _last_sync_error: Optional[Exception] = None
     _sync_debounce_s = 1.0
-
-    def initialize(self) -> None:
-        self._inbound_messages: Deque[Any] = deque()
-        self._inbound_lock = threading.Lock()
-        self._inbound_draining = False
-
-    @classmethod
-    def configure_message_workers(cls, config: Dict[str, Any]) -> None:
-        workers = _positive_int(
-            config.get("websocket_message_workers")
-            or os.getenv("HIVEMIND_WEBSOCKET_MESSAGE_WORKERS"),
-            DEFAULT_WEBSOCKET_MESSAGE_WORKERS,
-            "websocket_message_workers",
-        )
-        queue_size = _positive_int(
-            config.get("websocket_message_queue")
-            or os.getenv("HIVEMIND_WEBSOCKET_MESSAGE_QUEUE"),
-            DEFAULT_WEBSOCKET_MESSAGE_QUEUE,
-            "websocket_message_queue",
-        )
-        with cls._message_executor_lock:
-            cls._message_queue_size = queue_size
-            if cls._message_executor is None or cls._message_workers != workers:
-                old_executor = cls._message_executor
-                cls._message_workers = workers
-                cls._message_executor = ThreadPoolExecutor(
-                    max_workers=workers,
-                    thread_name_prefix="hivemind-ws-message",
-                )
-                if old_executor is not None:
-                    old_executor.shutdown(wait=False, cancel_futures=True)
-
-    @classmethod
-    def _executor(cls) -> ThreadPoolExecutor:
-        with cls._message_executor_lock:
-            if cls._message_executor is None:
-                cls._message_executor = ThreadPoolExecutor(
-                    max_workers=cls._message_workers,
-                    thread_name_prefix="hivemind-ws-message",
-                )
-            return cls._message_executor
 
     def _client_ip(self) -> Optional[str]:
         return resolve_client_ip(
@@ -329,37 +265,7 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         return name, key
 
     def on_message(self, message: str) -> None:
-        with self._inbound_lock:
-            if len(self._inbound_messages) >= self._message_queue_size:
-                LOG.warning(
-                    "closing websocket from "
-                    f"{self._current_peer_label()}: "
-                    "inbound message queue is full"
-                )
-                self.close(code=1013, reason="message queue full")
-                return
-            self._inbound_messages.append(message)
-            if self._inbound_draining:
-                return
-            self._inbound_draining = True
-        self._executor().submit(self._drain_inbound_messages)
-
-    def _drain_inbound_messages(self) -> None:
-        while True:
-            with self._inbound_lock:
-                if not self._inbound_messages:
-                    self._inbound_draining = False
-                    return
-                message = self._inbound_messages.popleft()
-            try:
-                self._handle_inbound_message(message)
-            except Exception:
-                LOG.exception(
-                    "failed to process websocket message from "
-                    f"{self._current_peer_label()}"
-                )
-                self.loop.add_callback(self.close)
-                return
+        self._handle_inbound_message(message)
 
     def _handle_inbound_message(self, message: str) -> None:
         message = self.client.decode(message)

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -294,6 +294,14 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             hm_protocol=self.hm_protocol
         )
         user: Client = self.hm_protocol.db.get_client_by_api_key(key)
+        if not user:
+            sync = getattr(self.hm_protocol.db, "sync", None)
+            if callable(sync):
+                try:
+                    sync()
+                    user = self.hm_protocol.db.get_client_by_api_key(key)
+                except Exception:
+                    LOG.exception("Client database sync failed while retrying api key lookup")
 
         if not user:
             LOG.error("Client provided an invalid api key")

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -20,7 +20,7 @@ from ovos_utils.xdg_utils import xdg_data_home
 from poorman_handshake import PasswordHandShake
 from tornado import ioloop
 from tornado import web
-from tornado.websocket import WebSocketHandler
+from tornado.websocket import WebSocketClosedError, WebSocketHandler
 
 from hivemind_bus_client.message import HiveMessageType
 try:
@@ -312,6 +312,12 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             def _write():
                 try:
                     self.write_message(payload, is_bin)
+                except WebSocketClosedError:
+                    LOG.debug(
+                        "Websocket already closed while writing to "
+                        f"{self._peer_label(getattr(self.client, 'peer', 'unknown'))}"
+                    )
+                    self.close()
                 except Exception as exc:
                     LOG.warning(
                         "Could not write websocket message to "

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -293,7 +293,6 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
             name=useragent,
             hm_protocol=self.hm_protocol
         )
-        self.hm_protocol.db.sync()
         user: Client = self.hm_protocol.db.get_client_by_api_key(key)
 
         if not user:

--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -309,12 +309,21 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
         LOG.info(f"Authorizing client from {self.source_ip or 'unknown'} - {useragent}:{key}")
 
         def do_send(payload: str, is_bin: bool):
-            self.loop.install()  # TODO is this needed?
-            self.write_message(payload, is_bin)
+            def _write():
+                try:
+                    self.write_message(payload, is_bin)
+                except Exception as exc:
+                    LOG.warning(
+                        "Could not write websocket message to "
+                        f"{self._peer_label(getattr(self.client, 'peer', 'unknown'))}: "
+                        f"{type(exc).__name__}: {exc!r}"
+                    )
+                    self.close()
+
+            self.loop.add_callback(_write)
 
         def do_disconnect():
-            self.loop.install()  # TODO is this needed?
-            self.close()
+            self.loop.add_callback(self.close)
 
         self.client = HiveMindClientConnection(
             key=key,

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -284,6 +284,24 @@ def test_open_reports_sync_failure_as_server_error():
     }
 
 
+def test_open_debounces_failed_sync_after_api_key_miss():
+    HiveMindTornadoWebSocket._last_sync_ts = 0.0
+    state = {"syncs": 0}
+
+    def fail_sync():
+        state["syncs"] += 1
+        raise RuntimeError("redis unavailable")
+
+    db = SimpleNamespace(
+        sync=fail_sync,
+        get_client_by_api_key=lambda key: None,
+    )
+    _open_handler(db, key="fresh-key", closes=[]).open()
+    _open_handler(db, key="fresh-key", invalid_clients=[]).open()
+
+    assert state["syncs"] == 1
+
+
 # --- self-signed cert generation ------------------------------------------
 
 def test_create_self_signed_cert_writes_files(tmp_path):

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -28,6 +28,12 @@ from hivemind_websocket_protocol import (
 from hivescope.node import MasterNode
 
 
+@pytest.fixture(autouse=True)
+def _reset_websocket_sync_state():
+    HiveMindTornadoWebSocket._last_sync_ts = 0.0
+    HiveMindTornadoWebSocket._last_sync_error = None
+
+
 # --- version.py module load ------------------------------------------------
 
 def test_version_module_exposes_constants_and_string():
@@ -208,6 +214,42 @@ def test_open_treats_closed_downstream_write_as_debug(monkeypatch):
     assert debugs
 
 
+def test_on_message_drains_inbound_frames_off_ioloop(monkeypatch):
+    submitted = []
+
+    class FakeExecutor:
+        def submit(self, callback):
+            submitted.append(callback)
+            return SimpleNamespace()
+
+    monkeypatch.setattr(
+        HiveMindTornadoWebSocket,
+        "_executor",
+        classmethod(lambda cls: FakeExecutor()),
+    )
+
+    handler = HiveMindTornadoWebSocket.__new__(HiveMindTornadoWebSocket)
+    handler.initialize()
+    handler.source_ip = None
+    handler.client = SimpleNamespace(peer="peer")
+    handler.close = lambda *args, **kwargs: None
+    handler.loop = SimpleNamespace(
+        add_callback=lambda callback, *args, **kwargs: callback(*args, **kwargs)
+    )
+    seen = []
+    handler._handle_inbound_message = seen.append
+
+    handler.on_message("one")
+    handler.on_message("two")
+
+    assert seen == []
+    assert len(submitted) == 1
+
+    submitted[0]()
+
+    assert seen == ["one", "two"]
+
+
 def test_open_uses_direct_api_key_lookup_without_sync():
     user = _auth_user()
 
@@ -327,10 +369,19 @@ def test_open_debounces_failed_sync_after_api_key_miss():
         sync=fail_sync,
         get_client_by_api_key=lambda key: None,
     )
-    _open_handler(db, key="fresh-key", closes=[]).open()
-    _open_handler(db, key="fresh-key", invalid_clients=[]).open()
+    closes = []
+    invalid_clients = []
+    _open_handler(db, key="fresh-key", closes=closes).open()
+    _open_handler(
+        db,
+        key="fresh-key",
+        closes=closes,
+        invalid_clients=invalid_clients,
+    ).open()
 
     assert state["syncs"] == 1
+    assert invalid_clients == []
+    assert [close["kwargs"]["code"] for close in closes] == [1011, 1011]
 
 
 # --- self-signed cert generation ------------------------------------------

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -11,7 +11,9 @@ import socket
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
+import pybase64
 import pytest
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 import asyncio
@@ -97,6 +99,58 @@ def test_websocket_ping_settings_non_finite_values_fall_back(monkeypatch, value)
         "websocket_ping_interval": DEFAULT_WEBSOCKET_PING_INTERVAL,
         "websocket_ping_timeout": DEFAULT_WEBSOCKET_PING_TIMEOUT,
     }
+
+
+# --- open() auth path ------------------------------------------------------
+
+def test_open_uses_direct_api_key_lookup_without_sync():
+    user = SimpleNamespace(
+        client_id=1,
+        name="unit-client",
+        crypto_key=None,
+        skill_blacklist=[],
+        intent_blacklist=[],
+        allowed_types=["recognizer_loop:utterance"],
+        can_broadcast=True,
+        can_propagate=True,
+        can_escalate=True,
+        is_admin=False,
+        password=None,
+    )
+
+    def fail_sync():
+        raise AssertionError("db.sync must not run on websocket open")
+
+    seen_clients = []
+    db = SimpleNamespace(
+        sync=fail_sync,
+        get_client_by_api_key=lambda key: user if key == "api-key" else None,
+    )
+    hm_protocol = SimpleNamespace(
+        db=db,
+        identity=SimpleNamespace(private_key=None),
+        handshake_enabled=True,
+        require_crypto=False,
+        handle_new_client=seen_clients.append,
+        handle_invalid_key_connected=lambda client: None,
+        handle_invalid_protocol_version=lambda client: None,
+    )
+
+    handler = HiveMindTornadoWebSocket.__new__(HiveMindTornadoWebSocket)
+    handler.hm_protocol = hm_protocol
+    handler.request = SimpleNamespace(remote_ip="127.0.0.1", headers={})
+    handler.application = SimpleNamespace(settings={})
+    handler.loop = SimpleNamespace(install=lambda: None)
+    handler.write_message = lambda payload, is_bin=False: None
+    handler.close = lambda *args, **kwargs: None
+    handler.get_query_argument = lambda name, default=None: pybase64.b64encode(
+        b"agent:api-key"
+    ).decode("ascii")
+
+    handler.open()
+
+    assert len(seen_clients) == 1
+    assert seen_clients[0].name == "agent::1::unit-client"
 
 
 # --- self-signed cert generation ------------------------------------------

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -357,8 +357,9 @@ def test_open_reports_sync_failure_as_server_error():
     }
 
 
-def test_open_debounces_failed_sync_after_api_key_miss():
+def test_open_debounces_failed_sync_after_api_key_miss(monkeypatch):
     HiveMindTornadoWebSocket._last_sync_ts = 0.0
+    monkeypatch.setattr(HiveMindTornadoWebSocket, "_sync_debounce_s", 60.0)
     state = {"syncs": 0}
 
     def fail_sync():

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -153,6 +153,64 @@ def test_open_uses_direct_api_key_lookup_without_sync():
     assert seen_clients[0].name == "agent::1::unit-client"
 
 
+def test_open_syncs_once_after_api_key_miss():
+    user = SimpleNamespace(
+        client_id=2,
+        name="fresh-client",
+        crypto_key=None,
+        skill_blacklist=[],
+        intent_blacklist=[],
+        allowed_types=["recognizer_loop:utterance"],
+        can_broadcast=True,
+        can_propagate=True,
+        can_escalate=True,
+        is_admin=False,
+        password=None,
+    )
+
+    state = {"synced": False, "syncs": 0}
+
+    def sync():
+        state["syncs"] += 1
+        state["synced"] = True
+
+    def lookup(key):
+        if key == "fresh-key" and state["synced"]:
+            return user
+        return None
+
+    seen_clients = []
+    invalid_clients = []
+    db = SimpleNamespace(sync=sync, get_client_by_api_key=lookup)
+    hm_protocol = SimpleNamespace(
+        db=db,
+        identity=SimpleNamespace(private_key=None),
+        handshake_enabled=True,
+        require_crypto=False,
+        handle_new_client=seen_clients.append,
+        handle_invalid_key_connected=invalid_clients.append,
+        handle_invalid_protocol_version=lambda client: None,
+    )
+
+    handler = HiveMindTornadoWebSocket.__new__(HiveMindTornadoWebSocket)
+    handler.hm_protocol = hm_protocol
+    handler.request = SimpleNamespace(remote_ip="127.0.0.1", headers={})
+    handler.application = SimpleNamespace(settings={})
+    handler.loop = SimpleNamespace(install=lambda: None)
+    handler.write_message = lambda payload, is_bin=False: None
+    handler.close = lambda *args, **kwargs: None
+    handler.get_query_argument = lambda name, default=None: pybase64.b64encode(
+        b"agent:fresh-key"
+    ).decode("ascii")
+
+    handler.open()
+
+    assert state["syncs"] == 1
+    assert len(invalid_clients) == 0
+    assert len(seen_clients) == 1
+    assert seen_clients[0].name == "agent::2::fresh-client"
+
+
 # --- self-signed cert generation ------------------------------------------
 
 def test_create_self_signed_cert_writes_files(tmp_path):

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -103,10 +103,10 @@ def test_websocket_ping_settings_non_finite_values_fall_back(monkeypatch, value)
 
 # --- open() auth path ------------------------------------------------------
 
-def test_open_uses_direct_api_key_lookup_without_sync():
-    user = SimpleNamespace(
-        client_id=1,
-        name="unit-client",
+def _auth_user(client_id=1, name="unit-client"):
+    return SimpleNamespace(
+        client_id=client_id,
+        name=name,
         crypto_key=None,
         skill_blacklist=[],
         intent_blacklist=[],
@@ -118,70 +118,12 @@ def test_open_uses_direct_api_key_lookup_without_sync():
         password=None,
     )
 
-    def fail_sync():
-        raise AssertionError("db.sync must not run on websocket open")
 
-    seen_clients = []
-    db = SimpleNamespace(
-        sync=fail_sync,
-        get_client_by_api_key=lambda key: user if key == "api-key" else None,
-    )
-    hm_protocol = SimpleNamespace(
-        db=db,
-        identity=SimpleNamespace(private_key=None),
-        handshake_enabled=True,
-        require_crypto=False,
-        handle_new_client=seen_clients.append,
-        handle_invalid_key_connected=lambda client: None,
-        handle_invalid_protocol_version=lambda client: None,
-    )
-
-    handler = HiveMindTornadoWebSocket.__new__(HiveMindTornadoWebSocket)
-    handler.hm_protocol = hm_protocol
-    handler.request = SimpleNamespace(remote_ip="127.0.0.1", headers={})
-    handler.application = SimpleNamespace(settings={})
-    handler.loop = SimpleNamespace(install=lambda: None)
-    handler.write_message = lambda payload, is_bin=False: None
-    handler.close = lambda *args, **kwargs: None
-    handler.get_query_argument = lambda name, default=None: pybase64.b64encode(
-        b"agent:api-key"
-    ).decode("ascii")
-
-    handler.open()
-
-    assert len(seen_clients) == 1
-    assert seen_clients[0].name == "agent::1::unit-client"
-
-
-def test_open_syncs_once_after_api_key_miss():
-    user = SimpleNamespace(
-        client_id=2,
-        name="fresh-client",
-        crypto_key=None,
-        skill_blacklist=[],
-        intent_blacklist=[],
-        allowed_types=["recognizer_loop:utterance"],
-        can_broadcast=True,
-        can_propagate=True,
-        can_escalate=True,
-        is_admin=False,
-        password=None,
-    )
-
-    state = {"synced": False, "syncs": 0}
-
-    def sync():
-        state["syncs"] += 1
-        state["synced"] = True
-
-    def lookup(key):
-        if key == "fresh-key" and state["synced"]:
-            return user
-        return None
-
-    seen_clients = []
-    invalid_clients = []
-    db = SimpleNamespace(sync=sync, get_client_by_api_key=lookup)
+def _open_handler(db, key="api-key", seen_clients=None,
+                  invalid_clients=None, closes=None):
+    seen_clients = seen_clients if seen_clients is not None else []
+    invalid_clients = invalid_clients if invalid_clients is not None else []
+    closes = closes if closes is not None else []
     hm_protocol = SimpleNamespace(
         db=db,
         identity=SimpleNamespace(private_key=None),
@@ -198,10 +140,58 @@ def test_open_syncs_once_after_api_key_miss():
     handler.application = SimpleNamespace(settings={})
     handler.loop = SimpleNamespace(install=lambda: None)
     handler.write_message = lambda payload, is_bin=False: None
-    handler.close = lambda *args, **kwargs: None
+    handler.close = lambda *args, **kwargs: closes.append(
+        {"args": args, "kwargs": kwargs}
+    )
     handler.get_query_argument = lambda name, default=None: pybase64.b64encode(
-        b"agent:fresh-key"
+        f"agent:{key}".encode("utf-8")
     ).decode("ascii")
+    return handler
+
+
+def test_open_uses_direct_api_key_lookup_without_sync():
+    user = _auth_user()
+
+    def fail_sync():
+        raise AssertionError("db.sync must not run on websocket open")
+
+    seen_clients = []
+    db = SimpleNamespace(
+        sync=fail_sync,
+        get_client_by_api_key=lambda key: user if key == "api-key" else None,
+    )
+    handler = _open_handler(db, seen_clients=seen_clients)
+
+    handler.open()
+
+    assert len(seen_clients) == 1
+    assert seen_clients[0].name == "agent::1::unit-client"
+
+
+def test_open_syncs_once_after_api_key_miss():
+    HiveMindTornadoWebSocket._last_sync_ts = 0.0
+    user = _auth_user(client_id=2, name="fresh-client")
+
+    state = {"synced": False, "syncs": 0}
+
+    def sync():
+        state["syncs"] += 1
+        state["synced"] = True
+
+    def lookup(key):
+        if key == "fresh-key" and state["synced"]:
+            return user
+        return None
+
+    seen_clients = []
+    invalid_clients = []
+    db = SimpleNamespace(sync=sync, get_client_by_api_key=lookup)
+    handler = _open_handler(
+        db,
+        key="fresh-key",
+        seen_clients=seen_clients,
+        invalid_clients=invalid_clients,
+    )
 
     handler.open()
 
@@ -209,6 +199,61 @@ def test_open_syncs_once_after_api_key_miss():
     assert len(invalid_clients) == 0
     assert len(seen_clients) == 1
     assert seen_clients[0].name == "agent::2::fresh-client"
+
+
+def test_open_debounces_sync_after_recent_api_key_miss():
+    HiveMindTornadoWebSocket._last_sync_ts = 0.0
+    user = _auth_user(client_id=3, name="synced-client")
+    state = {"synced": False, "syncs": 0}
+
+    def sync():
+        state["syncs"] += 1
+        state["synced"] = True
+
+    def lookup(key):
+        if key == "fresh-key" and state["synced"]:
+            return user
+        return None
+
+    db = SimpleNamespace(sync=sync, get_client_by_api_key=lookup)
+    seen_clients = []
+    invalid_clients = []
+    _open_handler(db, key="fresh-key",
+                  seen_clients=seen_clients).open()
+    _open_handler(db, key="missing-key",
+                  invalid_clients=invalid_clients).open()
+
+    assert state["syncs"] == 1
+    assert len(seen_clients) == 1
+    assert len(invalid_clients) == 1
+
+
+def test_open_reports_sync_failure_as_server_error():
+    HiveMindTornadoWebSocket._last_sync_ts = 0.0
+
+    def fail_sync():
+        raise RuntimeError("redis unavailable")
+
+    invalid_clients = []
+    closes = []
+    db = SimpleNamespace(
+        sync=fail_sync,
+        get_client_by_api_key=lambda key: None,
+    )
+    handler = _open_handler(
+        db,
+        key="fresh-key",
+        invalid_clients=invalid_clients,
+        closes=closes,
+    )
+
+    handler.open()
+
+    assert invalid_clients == []
+    assert closes[-1]["kwargs"] == {
+        "code": 1011,
+        "reason": "client database unavailable",
+    }
 
 
 # --- self-signed cert generation ------------------------------------------

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 import pybase64
 import pytest
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
+from tornado.websocket import WebSocketClosedError
 import asyncio
 
 from hivemind_websocket_protocol import (
@@ -175,6 +176,36 @@ def test_open_schedules_downstream_writes_on_ioloop():
     callback, args, kwargs = scheduled.pop()
     callback(*args, **kwargs)
     assert writes == [("payload", True)]
+
+
+def test_open_treats_closed_downstream_write_as_debug(monkeypatch):
+    user = _auth_user()
+    closes = []
+    warnings = []
+    debugs = []
+    handler = _open_handler(
+        SimpleNamespace(get_client_by_api_key=lambda key: user),
+        seen_clients=[],
+        closes=closes,
+    )
+    handler.write_message = lambda payload, is_bin=False: (_ for _ in ()).throw(
+        WebSocketClosedError()
+    )
+    monkeypatch.setattr(
+        "hivemind_websocket_protocol.LOG.warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        "hivemind_websocket_protocol.LOG.debug",
+        lambda *args, **kwargs: debugs.append((args, kwargs)),
+    )
+
+    handler.open()
+    handler.client.send_msg("payload", False)
+
+    assert closes
+    assert not warnings
+    assert debugs
 
 
 def test_open_uses_direct_api_key_lookup_without_sync():

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -138,7 +138,10 @@ def _open_handler(db, key="api-key", seen_clients=None,
     handler.hm_protocol = hm_protocol
     handler.request = SimpleNamespace(remote_ip="127.0.0.1", headers={})
     handler.application = SimpleNamespace(settings={})
-    handler.loop = SimpleNamespace(install=lambda: None)
+    handler.loop = SimpleNamespace(
+        install=lambda: None,
+        add_callback=lambda callback, *args, **kwargs: callback(*args, **kwargs),
+    )
     handler.write_message = lambda payload, is_bin=False: None
     handler.close = lambda *args, **kwargs: closes.append(
         {"args": args, "kwargs": kwargs}
@@ -147,6 +150,31 @@ def _open_handler(db, key="api-key", seen_clients=None,
         f"agent:{key}".encode("utf-8")
     ).decode("ascii")
     return handler
+
+
+def test_open_schedules_downstream_writes_on_ioloop():
+    user = _auth_user()
+    scheduled = []
+    writes = []
+    handler = _open_handler(
+        SimpleNamespace(get_client_by_api_key=lambda key: user),
+        seen_clients=[],
+    )
+    handler.loop = SimpleNamespace(
+        add_callback=lambda callback, *args, **kwargs: scheduled.append(
+            (callback, args, kwargs)
+        )
+    )
+    handler.write_message = lambda payload, is_bin=False: writes.append((payload, is_bin))
+
+    handler.open()
+    handler.client.send_msg("payload", True)
+
+    assert writes == []
+    assert len(scheduled) == 1
+    callback, args, kwargs = scheduled.pop()
+    callback(*args, **kwargs)
+    assert writes == [("payload", True)]
 
 
 def test_open_uses_direct_api_key_lookup_without_sync():

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -344,6 +344,27 @@ def test_run_starts_and_serves_on_plain_ws():
     assert not t.is_alive(), "run() did not return after ioloop.stop()"
 
 
+def test_run_raises_when_listener_bind_fails():
+    """Bind failures should propagate instead of looking like clean exits."""
+    master = MasterNode.create("MF", require_crypto=False, handshake_enabled=True)
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    blocker.bind(("127.0.0.1", 0))
+    blocker.listen(1)
+    port = blocker.getsockname()[1]
+    proto = HiveMindWebsocketProtocol(
+        config={"host": "127.0.0.1", "port": port, "ssl": False},
+        hm_protocol=master.hm_protocol,
+    )
+    if hasattr(HiveMindTornadoWebSocket, "loop"):
+        del HiveMindTornadoWebSocket.loop
+
+    try:
+        with pytest.raises(OSError):
+            proto.run()
+    finally:
+        blocker.close()
+
+
 def test_run_ssl_path_uses_existing_cert(tmp_path):
     """SSL branch in run(): existing cert is picked up; no regeneration."""
     cert, key = HiveMindWebsocketProtocol.create_self_signed_cert(

--- a/tests/test_protocol_unit.py
+++ b/tests/test_protocol_unit.py
@@ -214,42 +214,6 @@ def test_open_treats_closed_downstream_write_as_debug(monkeypatch):
     assert debugs
 
 
-def test_on_message_drains_inbound_frames_off_ioloop(monkeypatch):
-    submitted = []
-
-    class FakeExecutor:
-        def submit(self, callback):
-            submitted.append(callback)
-            return SimpleNamespace()
-
-    monkeypatch.setattr(
-        HiveMindTornadoWebSocket,
-        "_executor",
-        classmethod(lambda cls: FakeExecutor()),
-    )
-
-    handler = HiveMindTornadoWebSocket.__new__(HiveMindTornadoWebSocket)
-    handler.initialize()
-    handler.source_ip = None
-    handler.client = SimpleNamespace(peer="peer")
-    handler.close = lambda *args, **kwargs: None
-    handler.loop = SimpleNamespace(
-        add_callback=lambda callback, *args, **kwargs: callback(*args, **kwargs)
-    )
-    seen = []
-    handler._handle_inbound_message = seen.append
-
-    handler.on_message("one")
-    handler.on_message("two")
-
-    assert seen == []
-    assert len(submitted) == 1
-
-    submitted[0]()
-
-    assert seen == ["one", "two"]
-
-
 def test_open_uses_direct_api_key_lookup_without_sync():
     user = _auth_user()
 


### PR DESCRIPTION
Keeps websocket writes and closes on the Tornado IOLoop, propagates listener bind failures, and moves client DB sync to a debounced retry only after an API-key miss.

Reduced after review: the inbound ThreadPoolExecutor drainer and its config knobs were removed. on_message is serialized again.

Tested:
- PYTHONPATH=. pytest tests/test_protocol_unit.py -q