### PR TITLE
refactor: drop dead blacklist assignments

### DIFF
--- a/hivemind_websocket_protocol/__init__.py
+++ b/hivemind_websocket_protocol/__init__.py
@@ -400,8 +400,6 @@ class HiveMindTornadoWebSocket(WebSocketHandler):
 
         self.client.name = f"{useragent}::{user.client_id}::{user.name}"
         self.client.crypto_key = user.crypto_key
-        self.client.skill_blacklist = user.skill_blacklist or []
-        self.client.intent_blacklist = user.intent_blacklist or []
         self.client.allowed_types = user.allowed_types
         self.client.can_broadcast = user.can_broadcast
         self.client.can_propagate = user.can_propagate


### PR DESCRIPTION
Stacked on #37 (which stacks on #36) — rebuilt as a single cherry-pick on that stack after the previous branch carried unrelated fork history and conflicted with dev.

Drops the dead per-connection blacklist assignments in `open()`:

```python
self.client.skill_blacklist = user.skill_blacklist or []
self.client.intent_blacklist = user.intent_blacklist or []
```

`HiveMindClientConnection` declares neither field and nothing reads them off the connection — skill/intent blacklist enforcement lives in the agent policy layer, which reads the DB row directly. The websocket transport copying them onto the connection is a leftover from before that move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)